### PR TITLE
fixing store tests

### DIFF
--- a/xlab/data/store/BUILD
+++ b/xlab/data/store/BUILD
@@ -8,6 +8,7 @@ py_library(
     srcs = ["interface.py"],
     srcs_version = "PY3",
     deps = [
+        ":units",
         "//xlab/data/proto:data_entry_py_pb2",
     ],
 )
@@ -18,6 +19,7 @@ py_library(
     srcs = ["impl_test_factory.py"],
     deps = [
         ":interface",
+        ":key",
         "//xlab/data/proto:data_entry_py_pb2",
         "//xlab/net/proto/testing:compare",
         "//xlab/net/proto/testing:parse",
@@ -32,6 +34,7 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":interface",
+        ":units",
         "//xlab/data/proto:data_entry_py_pb2",
     ],
 )
@@ -43,4 +46,10 @@ py_test(
         ":key",
         requirement("absl-py"),
     ],
+)
+
+py_library(
+    name = "units",
+    srcs = ["units.py"],
+    srcs_version = "PY3",
 )

--- a/xlab/data/store/in_memory/store.py
+++ b/xlab/data/store/in_memory/store.py
@@ -25,19 +25,19 @@ class InMemoryDataStore(interface.DataStore):
     def add(self, data_entry: data_entry_pb2.DataEntry):
         data_key = key.make_key(data_entry)
         data_entries = self._data[data_key]
-        if data_entry.timestamp.ToDatetime() in {
-                e.timestamp.ToDatetime() for e in data_entries
+        if data_entry.timestamp.ToSeconds() in {
+                e.timestamp.ToSeconds() for e in data_entries
         }:
             raise errors.AlreadyExistsError(
                 f'The data entry to add already exists: {data_entry}')
         self._data[data_key].append(data_entry)
-        self._data[data_key].sort(key=lambda e: e.timestamp.ToDatetime())
+        self._data[data_key].sort(key=lambda e: e.timestamp.ToSeconds())
 
     def read(self, lookup_key: interface.LookupKey) -> data_entry_pb2.DataEntry:
         data_entries = self._data[key.from_lookup_key(lookup_key)]
         try:
             return next(e for e in data_entries
-                        if e.timestamp.ToDatetime() == lookup_key.timestamp)
+                        if e.timestamp.ToSeconds() == lookup_key.timestamp)
         except StopIteration:
             raise errors.NotFoundError(
                 f'Cannot find data matching lookup key: {lookup_key}')
@@ -50,7 +50,7 @@ class InMemoryDataStore(interface.DataStore):
                 continue
             results.extend((e for e in data_entries
                             if lookup_key.timestamp is None or
-                            e.timestamp.ToDatetime() == lookup_key.timestamp))
+                            e.timestamp.ToSeconds() == lookup_key.timestamp))
         # Return a value, as extend makes copies.
         data_entries = data_entry_pb2.DataEntries()
         data_entries.entries.extend(results)

--- a/xlab/data/store/in_memory/store_test.py
+++ b/xlab/data/store/in_memory/store_test.py
@@ -3,8 +3,11 @@ from absl.testing import absltest
 from xlab.data.store import impl_test_factory
 from xlab.data.store.in_memory import store
 
-# Test that the implementation fulfills the interface.
-impl_test_factory.make_data_provider_test_case(store.InMemoryDataStore())
+
+class InMemoryDataStoreTest(
+        impl_test_factory.create(lambda: store.InMemoryDataStore())):
+    pass
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/xlab/data/store/interface.py
+++ b/xlab/data/store/interface.py
@@ -4,6 +4,7 @@ import datetime
 from typing import Callable, List, Optional
 
 from xlab.data.proto import data_entry_pb2
+from xlab.data.store import units
 
 
 # Fields for retrieving data entries.
@@ -13,7 +14,7 @@ class LookupKey:
     data_space: Optional[int] = None
     symbol: Optional[str] = None
     data_type: Optional[str] = None
-    timestamp: Optional[datetime.datetime] = None
+    timestamp: Optional[units.Seconds] = None
 
 
 class DataStore(abc.ABC):

--- a/xlab/data/store/key.py
+++ b/xlab/data/store/key.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 
 from xlab.data.proto import data_entry_pb2
-from xlab.data.store import interface
+from xlab.data.store import interface, units
 
 # DataSpace, symbol, data_type
 DataKey = Tuple[int, str, str]
@@ -26,3 +26,12 @@ def key_matches(data_key: DataKey, lookup_key: interface.LookupKey) -> bool:
 
 def from_lookup_key(lookup_key: interface.LookupKey) -> DataKey:
     return (lookup_key.data_space, lookup_key.symbol, lookup_key.data_type)
+
+
+def make_lookup_key(
+        data_entry: data_entry_pb2.DataEntry) -> interface.LookupKey:
+    return interface.LookupKey(data_space=int(data_entry.data_space),
+                               symbol=data_entry.symbol,
+                               data_type=data_entry.data_type,
+                               timestamp=units.Seconds(
+                                   data_entry.timestamp.ToSeconds()))

--- a/xlab/data/store/mongo/db_client.py
+++ b/xlab/data/store/mongo/db_client.py
@@ -1,13 +1,9 @@
 import pymongo
-from pymongo import database
 
 _LOCAL_HOST = 'localhost'
 _DEFAULT_PORT = 27017
-_DATABASE = 'xlab'
 
 
 def connect(host: str = _LOCAL_HOST,
-            port: int = _DEFAULT_PORT,
-            db: str = _DATABASE) -> database.Database:
-    client = pymongo.MongoClient(host, port)
-    return client[db]
+            port: int = _DEFAULT_PORT) -> pymongo.MongoClient:
+    return pymongo.MongoClient(host, port)

--- a/xlab/data/store/mongo/store.py
+++ b/xlab/data/store/mongo/store.py
@@ -1,24 +1,34 @@
 from typing import Callable, Dict, List, Tuple
 
 from google.protobuf import json_format, timestamp_pb2
-from pymongo import database
+import pymongo
+from pymongo import client_session
 
 from xlab.data.proto import data_entry_pb2
 from xlab.data.store import interface, key
-from xlab.util.status import errors
-
 from xlab.data.store.mongo import db_client
+from xlab.util.status import errors
 
 
 class MongoDataStore(interface.DataStore):
 
+    _DATABASE = 'xlab'
     _DATA_ENTRY_COLLECTION = 'data_entries'
 
-    def __init__(self, db: database.Database = db_client.connect()):
-        self._db = db
+    def __init__(self, client: pymongo.MongoClient = db_client.connect()):
+        self._client = client
+        self._db = self._client[self._DATABASE]
         self._coll = self._db[self._DATA_ENTRY_COLLECTION]
 
     def add(self, data_entry: data_entry_pb2.DataEntry):
+        # TODO: causal_consistency should be supported with |start_session|;
+        # however, this is not supported by the mock: https://github.com/mongomock/mongomock/issues/614
+        lookup_key = key.make_lookup_key(data_entry)
+        record = self._coll.find_one(self._get_filter(lookup_key))
+        if record is not None:
+            raise errors.AlreadyExistsError(
+                f'The data entry to add already exists: {record}')
+
         self._coll.insert_one(
             json_format.MessageToDict(data_entry, use_integers_for_enums=True))
 
@@ -29,29 +39,39 @@ class MongoDataStore(interface.DataStore):
         ])
 
     def read(self, lookup_key: interface.LookupKey) -> data_entry_pb2.DataEntry:
-        record = self._coll.find_one(get_filter(lookup_key))
-        return json_format.ParseDict(record)
+        record = self._coll.find_one(self._get_filter(lookup_key))
+        if record is None:
+            raise errors.NotFoundError(
+                f'Cannot find data matching lookup key: {lookup_key}')
+        return self._parse(record)
 
     def lookup(self,
                lookup_key: interface.LookupKey) -> data_entry_pb2.DataEntries:
-        cursor = self._coll.find(get_filter(lookup_key))
-        return [json_format.ParseDict(record) for record in cursor]
+        cursor = self._coll.find(self._get_filter(lookup_key))
+        return [self._parse(record) for record in cursor]
 
     def each(self, fn: Callable[[data_entry_pb2.DataEntry], None]):
         all_cursor = self._coll.find()
         for record in all_cursor:
-            fn(json_format.ParseDict(record))
+            fn(self._parse(record))
 
-    def get_filter(self, lookup_key: interface.LookupKey) -> Dict:
+    def _parse(self, document: Dict) -> data_entry_pb2.DataEntry:
+        # ParseDict takes a message type and also return it as results
+        # ignore_unknown_fields is used to ignore mongo's _id field.
+        return json_format.ParseDict(document,
+                                     data_entry_pb2.DataEntry(),
+                                     ignore_unknown_fields=True)
+
+    def _get_filter(self, lookup_key: interface.LookupKey) -> Dict:
         res = {}
         if lookup_key.data_space is not None:
-            res['data_space'] = lookup_key.data_space
+            res['dataSpace'] = lookup_key.data_space
         if lookup_key.symbol is not None:
             res['symbol'] = lookup_key.symbol
         if lookup_key.data_type is not None:
-            res['data_type'] = lookup_key.data_type
+            res['dataType'] = lookup_key.data_type
         if lookup_key.timestamp is not None:
             timestamp_proto = timestamp_pb2.Timestamp()
-            timestamp_proto.FromDatetime(lookup_key.timestamp)
-            res['timestamp'] = json_format.MessageToDict(timestamp_proto)
+            timestamp_proto.FromSeconds(lookup_key.timestamp)
+            res['timestamp'] = timestamp_proto.ToJsonString()
         return res

--- a/xlab/data/store/mongo/store_test.py
+++ b/xlab/data/store/mongo/store_test.py
@@ -5,9 +5,12 @@ import mongomock
 from xlab.data.store import impl_test_factory
 from xlab.data.store.mongo import store
 
-mongo_store = store.MongoDataStore(mongomock.MongoClient().db)
-# Test that the implementation fulfills the interface.
-impl_test_factory.make_data_provider_test_case(mongo_store)
+
+class MongoDataStoreTest(
+        impl_test_factory.create(
+            lambda: store.MongoDataStore(mongomock.MongoClient()))):
+    pass
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/xlab/data/store/textproto/store_test.py
+++ b/xlab/data/store/textproto/store_test.py
@@ -3,9 +3,12 @@ from absl.testing import absltest
 from xlab.data.store import impl_test_factory
 from xlab.data.store.textproto import store
 
-# Test that the implementation fulfills the interface.
-impl_test_factory.make_data_provider_test_case(
-    store.TextProtoDataStore(data_store_directory='/tmp'))
+
+class TextProtoDataStoreTest(
+        impl_test_factory.create(
+            lambda: store.TextProtoDataStore(data_store_directory='/tmp'))):
+    pass
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/xlab/data/store/units.py
+++ b/xlab/data/store/units.py
@@ -1,0 +1,5 @@
+from typing import NewType
+
+# A practical precision for saving data points.
+# This also helps ignore loss of precision in various cases.
+Seconds = NewType('Seconds', int)


### PR DESCRIPTION
These tests were not actually triggering given the way I invoke the test factories. The mongo implementation turned out need much work.

One major change is to stop using `datetime` for lookup, as its precision is lower than the `Timestamp` protobuf type. As a result, all timestamps for data lookup and storage are unified to use seconds instead.