### PR TITLE
Introduce data_type proto enum + Fix parameterized tests

### DIFF
--- a/xlab/data/proto/BUILD
+++ b/xlab/data/proto/BUILD
@@ -6,10 +6,23 @@ package(default_visibility = ["//xlab:internal"])
 proto_library(
     name = "data_entry_proto",
     srcs = ["data_entry.proto"],
-    deps = ["@com_google_protobuf//:timestamp_proto"],
+    deps = [
+        "data_type_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
 )
 
 py_proto_library(
     name = "data_entry_py_pb2",
     deps = [":data_entry_proto"],
+)
+
+proto_library(
+    name = "data_type_proto",
+    srcs = ["data_type.proto"],
+)
+
+py_proto_library(
+    name = "data_type_py_pb2",
+    deps = [":data_type_proto"],
 )

--- a/xlab/data/proto/data_entry.proto
+++ b/xlab/data/proto/data_entry.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package xlab;
 
 import "google/protobuf/timestamp.proto";
+import "xlab/data/proto/data_type.proto";
 
 message DataEntries {
   repeated DataEntry entries = 1;
@@ -20,7 +21,7 @@ message DataEntry {
   DataSpace data_space = 2;
 
   // The type of the data, e.g. Close price vs. Volume.
-  string data_type = 3;
+  DataType.Enum data_type = 3;
 
   double value = 4;
 

--- a/xlab/data/proto/data_type.proto
+++ b/xlab/data/proto/data_type.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package xlab;
 
 message DataType {
-  // Next ID: 4. Keep alphabetically sorted.
+  // Next ID: 5. Keep alphabetically sorted.
   enum Enum {
     UNSPECIFIED_CALC_TYPE = 0;
     CLOSE_PRICE = 1;

--- a/xlab/data/proto/data_type.proto
+++ b/xlab/data/proto/data_type.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package xlab;
+
+message DataType {
+  // Next ID: 4. Keep alphabetically sorted.
+  enum Enum {
+    UNSPECIFIED_CALC_TYPE = 0;
+    CLOSE_PRICE = 1;
+    EMA = 2; // Exponential Moving Average.
+    OPEN_PRICE = 4;
+    VOLUME = 3;
+  }
+}

--- a/xlab/data/provider/iex/BUILD
+++ b/xlab/data/provider/iex/BUILD
@@ -28,6 +28,7 @@ py_library(
     deps = [
         ":api",
         "//xlab/data/proto:data_entry_py_pb2",
+        "//xlab/data/proto:data_type_py_pb2",
         "//xlab/data/provider:interface",
     ],
 )
@@ -37,6 +38,7 @@ py_test(
     srcs = ["provider_test.py"],
     deps = [
         ":provider",
+        "//xlab/data/proto:data_type_py_pb2",
         "//xlab/net/proto/testing:compare",
         requirement("absl-py"),
         requirement("requests"),

--- a/xlab/data/provider/iex/provider.py
+++ b/xlab/data/provider/iex/provider.py
@@ -2,7 +2,7 @@ import datetime
 
 from typing import Dict, List
 
-from xlab.data.proto import data_entry_pb2
+from xlab.data.proto import data_entry_pb2, data_type_pb2
 from xlab.data.provider import interface
 from xlab.data.provider.iex import api
 
@@ -34,16 +34,19 @@ class IexDataProvider(interface.DataProvider):
                                                    '%Y-%m-%d')
 
             close_data = self._make_data_base(symbol, data_date, now)
-            close_data.data_type = 'close'
+            close_data.data_type = data_type_pb2.DataType.CLOSE_PRICE
             close_data.value = chart_data['close']
             close_results.append(close_data)
 
             volume_data = self._make_data_base(symbol, data_date, now)
-            volume_data.data_type = 'volume'
+            volume_data.data_type = data_type_pb2.DataType.VOLUME
             volume_data.value = chart_data['volume']
             volume_results.append(volume_data)
 
-        return {'close': close_results, 'volume': volume_results}
+        return {
+            data_type_pb2.DataType.CLOSE_PRICE: close_results,
+            data_type_pb2.DataType.VOLUME: volume_results
+        }
 
     def _make_data_base(self, symbol: str, data_date: datetime.datetime,
                         now: datetime.datetime) -> data_entry_pb2.DataEntry:

--- a/xlab/data/provider/iex/provider_test.py
+++ b/xlab/data/provider/iex/provider_test.py
@@ -6,6 +6,7 @@ from absl.testing import absltest
 import requests
 from requests import exceptions as request_exceptions
 
+from xlab.data.proto import data_type_pb2
 from xlab.data.provider.iex import api, provider
 from xlab.net.proto.testing import compare
 
@@ -47,38 +48,40 @@ class IexDataProviderTest(absltest.TestCase):
         _, kwargs = mock_get.call_args
         self.assertEqual(kwargs['params']['symbols'], 'SPY')
 
-        self.assertEqual(len(results['close']), 2)
+        close_data = results[data_type_pb2.DataType.CLOSE_PRICE]
+        self.assertEqual(len(close_data), 2)
         compare.assertProtoEqual(
-            self, results['close'][0], """
+            self, close_data[0], """
             symbol: "SPY"
             data_space: STOCK_DATA
-            data_type: "close"
+            data_type: CLOSE_PRICE
             value: 319.69
             timestamp { seconds: 1583107200 }
             updated_at { seconds: 1609372800 }""")
         compare.assertProtoEqual(
-            self, results['close'][1], """
+            self, close_data[1], """
             symbol: "SPY"
             data_space: STOCK_DATA
-            data_type: "close"
+            data_type: CLOSE_PRICE
             value: 308.48
             timestamp { seconds: 1583193600 }
             updated_at { seconds: 1609372800 }""")
 
-        self.assertEqual(len(results['close']), 2)
+        volume_data = results[data_type_pb2.DataType.VOLUME]
+        self.assertEqual(len(volume_data), 2)
         compare.assertProtoEqual(
-            self, results['volume'][0], """
+            self, volume_data[0], """
             symbol: "SPY"
             data_space: STOCK_DATA
-            data_type: "volume"
+            data_type: VOLUME
             value: 242964067.0
             timestamp { seconds: 1583107200 }
             updated_at { seconds: 1609372800 }""")
         compare.assertProtoEqual(
-            self, results['volume'][1], """
+            self, volume_data[1], """
             symbol: "SPY"
             data_space: STOCK_DATA
-            data_type: "volume"
+            data_type: VOLUME
             value: 300862938.0
             timestamp { seconds: 1583193600 }
             updated_at { seconds: 1609372800 }""")

--- a/xlab/data/store/BUILD
+++ b/xlab/data/store/BUILD
@@ -21,6 +21,7 @@ py_library(
         ":interface",
         ":key",
         "//xlab/data/proto:data_entry_py_pb2",
+        "//xlab/data/proto:data_type_py_pb2",
         "//xlab/net/proto/testing:compare",
         "//xlab/net/proto/testing:parse",
         requirement("absl-py"),
@@ -36,6 +37,7 @@ py_library(
         ":interface",
         ":units",
         "//xlab/data/proto:data_entry_py_pb2",
+        "//xlab/data/proto:data_type_py_pb2",
     ],
 )
 
@@ -44,6 +46,8 @@ py_test(
     srcs = ["key_test.py"],
     deps = [
         ":key",
+        "//xlab/data/proto:data_entry_py_pb2",
+        "//xlab/data/proto:data_type_py_pb2",
         requirement("absl-py"),
     ],
 )

--- a/xlab/data/store/impl_test_factory.py
+++ b/xlab/data/store/impl_test_factory.py
@@ -1,108 +1,87 @@
-from typing import Callable
+from typing import Callable, Tuple
+import unittest
 
 from absl.testing import absltest, parameterized
 from google.protobuf import timestamp_pb2
 
 from xlab.data.store import interface, key, units
-from xlab.data.proto import data_entry_pb2
+from xlab.data.proto import data_entry_pb2, data_type_pb2
 from xlab.net.proto.testing import compare, parse
 from xlab.util.status import errors
 
-_DATA_ENTRY1 = """
-data_space: STOCK_DATA
-symbol: "SPY"
-data_type: "close"
-value: 290.87
-timestamp {
-  seconds: 1234567
-}
-"""
-
-_DATA_ENTRY2 = """
-data_space: STOCK_DATA
-symbol: "SPY"
-data_type: "close"
-value: 300.01
-timestamp {
-  seconds: 567890
-}
-"""
-
-_DATA_ENTRY3 = """
-data_space: STOCK_DATA
-symbol: "BA"
-data_type: "close"
-value: 115.32
-timestamp {
-  seconds: 1234567
-}
-"""
+StoreFactory = Callable[[], interface.DataStore]
 
 
-def create(impl_factory: Callable[[], interface.DataStore]):
+def get_data_entry_one():
+    return parse.parse_test_proto(
+        """
+        data_space: STOCK_DATA
+        symbol: "SPY"
+        data_type: CLOSE_PRICE
+        value: 290.87
+        timestamp {
+        seconds: 1234567
+        }""", data_entry_pb2.DataEntry)
 
-    class DataStoreTestCaseBase(absltest.TestCase):
+
+def get_data_entry_two():
+    return parse.parse_test_proto(
+        """
+        data_space: STOCK_DATA
+        symbol: "SPY"
+        data_type: CLOSE_PRICE
+        value: 300.01
+        timestamp {
+        seconds: 567890
+        }""", data_entry_pb2.DataEntry)
+
+
+def get_data_entry_three():
+    return parse.parse_test_proto(
+        """
+        data_space: STOCK_DATA
+        symbol: "BA"
+        data_type: CLOSE_PRICE
+        value: 115.32
+        timestamp {
+        seconds: 1234567
+        }
+        """, data_entry_pb2.DataEntry)
+
+
+def create(impl_factory: StoreFactory) -> absltest.TestCase:
+
+    class DataStoreTestCase(absltest.TestCase):
 
         def setUp(self):
             self._store = impl_factory()
-            self._data_entry1 = parse.parse_test_proto(_DATA_ENTRY1,
-                                                       data_entry_pb2.DataEntry)
 
         def test_add_then_read(self):
-            self._store.add(self._data_entry1)
+            self._store.add(get_data_entry_one())
 
-            lookup_key = key.make_lookup_key(self._data_entry1)
+            lookup_key = key.make_lookup_key(get_data_entry_one())
             compare.assertProtoEqual(self, self._store.read(lookup_key),
-                                     _DATA_ENTRY1)
+                                     get_data_entry_one())
 
         def test_add_data_entry_with_the_same_timestamp(self):
-            self._store.add(self._data_entry1)
+            self._store.add(get_data_entry_one())
             with self.assertRaises(errors.AlreadyExistsError):
-                self._store.add(self._data_entry1)
+                self._store.add(get_data_entry_one())
 
         def test_read_data_that_does_not_exist(self):
-            self._store.add(self._data_entry1)
+            self._store.add(get_data_entry_one())
 
             with self.assertRaises(errors.NotFoundError):
                 lookup_key = interface.LookupKey(
                     data_space=int(data_entry_pb2.DataEntry.STOCK_DATA),
                     symbol="SPY",
-                    data_type="close",
+                    data_type=data_type_pb2.DataType.CLOSE_PRICE,
                     timestamp=units.Seconds(
                         timestamp_pb2.Timestamp(seconds=654321).ToSeconds()))
                 self._store.read(lookup_key)
 
-        class LookupTest(parameterized.TestCase):
-
-            @parameterized.parameters(
-                (data_entry_pb2.DataEntry.STOCK_DATA, "SPY", "close",
-                 (_DATA_ENTRY1, _DATA_ENTRY2)),
-                (data_entry_pb2.DataEntry.STOCK_DATA, "BA", "close",
-                 (_DATA_ENTRY3)),
-                (data_entry_pb2.DataEntry.STOCK_DATA, None, None,
-                 (_DATA_ENTRY1, _DATA_ENTRY2, _DATA_ENTRY3)),
-                (data_entry_pb2.DataEntry.STOCK_DATA, "BA", "open", ()))
-            def test_lookup(self, data_space, symbol, data_type, data_entries):
-                self._store.add(
-                    parse.parse_test_proto(_DATA_ENTRY1,
-                                           data_entry_pb2.DataEntry))
-                self._store.add(
-                    parse.parse_test_proto(_DATA_ENTRY2,
-                                           data_entry_pb2.DataEntry))
-                self._store.add(
-                    parse.parse_test_proto(_DATA_ENTRY3,
-                                           data_entry_pb2.DataEntry))
-
-                lookup_key = interface.LookupKey(data_space=data_space,
-                                                 symbol=symol,
-                                                 data_type=data_type)
-                expected = data_entry_pb2.DataEntries()
-                expected.entries.extend(data_entries)
-                compare.assertProtoEqual(self, self._store.lookup(lookup_key),
-                                         expected)
-
         def test_each(self):
-            self._store.add(self._data_entry1)
+            self._store.add(get_data_entry_one())
             count = 0
 
             def inc(payload):
@@ -113,4 +92,44 @@ def create(impl_factory: Callable[[], interface.DataStore]):
             self._store.each(inc)
             self.assertEqual(count, 1)
 
-    return DataStoreTestCaseBase
+    return DataStoreTestCase
+
+
+def create_parameterized_test(
+        impl_factory: StoreFactory) -> parameterized.TestCase:
+
+    class ParameterizedLookupTest(parameterized.TestCase):
+
+        @parameterized.named_parameters(
+            ("Two matches", data_entry_pb2.DataEntry.STOCK_DATA, "SPY",
+             data_type_pb2.DataType.CLOSE_PRICE,
+             (get_data_entry_one(), get_data_entry_two())),
+            ("One match", data_entry_pb2.DataEntry.STOCK_DATA, "BA",
+             data_type_pb2.DataType.CLOSE_PRICE, (get_data_entry_three(),)),
+            ("All matches", data_entry_pb2.DataEntry.STOCK_DATA, None, 0,
+             (get_data_entry_one(), get_data_entry_two(),
+              get_data_entry_three())),
+            ("No match", data_entry_pb2.DataEntry.STOCK_DATA, "BA",
+             data_type_pb2.DataType.OPEN_PRICE, ()))
+        def test_lookup(self, data_space: data_entry_pb2.DataEntry.DataSpace,
+                        symbol: str, data_type: data_type_pb2.DataType.Enum,
+                        data_entries: Tuple[data_entry_pb2.DataEntry]):
+            store = impl_factory()
+            store.add(get_data_entry_one())
+            store.add(get_data_entry_two())
+            store.add(get_data_entry_three())
+
+            lookup_key = interface.LookupKey(data_space=data_space,
+                                             symbol=symbol or "",
+                                             data_type=data_type)
+            actual = store.lookup(lookup_key)
+
+            expected = data_entry_pb2.DataEntries()
+            expected.entries.extend(data_entries)
+
+            # Sort to ignore repeated field ordering.
+            actual.entries.sort(key=str)
+            expected.entries.sort(key=str)
+            compare.assertProtoEqual(self, actual, expected)
+
+    return ParameterizedLookupTest

--- a/xlab/data/store/in_memory/store_test.py
+++ b/xlab/data/store/in_memory/store_test.py
@@ -3,9 +3,15 @@ from absl.testing import absltest
 from xlab.data.store import impl_test_factory
 from xlab.data.store.in_memory import store
 
+store_factory = store.InMemoryDataStore
 
-class InMemoryDataStoreTest(
-        impl_test_factory.create(lambda: store.InMemoryDataStore())):
+
+class InMemoryDataStoreTest(impl_test_factory.create(store_factory)):
+    pass
+
+
+class InMemoryDataStoreParameterizedTest(
+        impl_test_factory.create_parameterized_test(store_factory)):
     pass
 
 

--- a/xlab/data/store/interface.py
+++ b/xlab/data/store/interface.py
@@ -3,17 +3,16 @@ import dataclasses
 import datetime
 from typing import Callable, List, Optional
 
-from xlab.data.proto import data_entry_pb2
+from xlab.data.proto import data_entry_pb2, data_type_pb2
 from xlab.data.store import units
 
 
 # Fields for retrieving data entries.
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class LookupKey:
-    # An xlab.DataEntry.DataSpace Enum. Incompatible with Optional type.
-    data_space: Optional[int] = None
+    data_space: int = 0  # Prot Enum data_entry_pb2.DataEntry.DataSpace
     symbol: Optional[str] = None
-    data_type: Optional[str] = None
+    data_type: int = 0 # Proto Enum data_type_pb2.DataType.Enum
     timestamp: Optional[units.Seconds] = None
 
 

--- a/xlab/data/store/key.py
+++ b/xlab/data/store/key.py
@@ -1,10 +1,12 @@
 from typing import Tuple
 
-from xlab.data.proto import data_entry_pb2
+from xlab.data.proto import data_entry_pb2, data_type_pb2
 from xlab.data.store import interface, units
 
-# DataSpace, symbol, data_type
-DataKey = Tuple[int, str, str]
+DataKey = Tuple[int,  # Prot Enum data_entry_pb2.DataEntry.DataSpace
+                str,  # symbol
+                int,  # Proto Enum data_type_pb2.DataType.Enum
+               ]
 
 
 def make_key(data_entry: data_entry_pb2.DataEntry) -> DataKey:
@@ -16,12 +18,10 @@ def make_key(data_entry: data_entry_pb2.DataEntry) -> DataKey:
 
 
 def key_matches(data_key: DataKey, lookup_key: interface.LookupKey) -> bool:
-    return not ((lookup_key.data_space is not None and
-                 lookup_key.data_space != data_key.data_space) or
-                (lookup_key.symbol is not None and
-                 lookup_key.symbol != data_key.symbol) or
-                (lookup_key.data_type is not None and
-                 lookup_key.data_type != data_key.data_type))
+    data_space, symbol, data_type = data_key
+    return ((not lookup_key.data_space or lookup_key.data_space == data_space)
+            and (not lookup_key.symbol or lookup_key.symbol == symbol) and
+            (not lookup_key.data_type or lookup_key.data_type == data_type))
 
 
 def from_lookup_key(lookup_key: interface.LookupKey) -> DataKey:
@@ -30,7 +30,7 @@ def from_lookup_key(lookup_key: interface.LookupKey) -> DataKey:
 
 def make_lookup_key(
         data_entry: data_entry_pb2.DataEntry) -> interface.LookupKey:
-    return interface.LookupKey(data_space=int(data_entry.data_space),
+    return interface.LookupKey(data_space=data_entry.data_space,
                                symbol=data_entry.symbol,
                                data_type=data_entry.data_type,
                                timestamp=units.Seconds(

--- a/xlab/data/store/key_test.py
+++ b/xlab/data/store/key_test.py
@@ -1,22 +1,23 @@
 from absl.testing import absltest, parameterized
 
 from xlab.data.store import key
-from xlab.data.proto import data_entry_pb2
+from xlab.data.proto import data_entry_pb2, data_type_pb2
 
 
-class DataStoreKeyTest(absltest.TestCase):
+class DataStoreKeyParameterizedTest(parameterized.TestCase):
 
-    class KeyParameterizedTest(parameterized.TestCase):
-
-        @parameterized.parameters(
-            (data_entry_pb2.DataEntry.STOCK_DATA, "IBM", "close"),
-            (data_entry_pb2.DataEntry.STOCK_METADATA, "BA", "open"))
-        def test_make_key(self, data_space, symbol, data_type):
-            data_entry = data_entry_pb2.DataEntry(data_space=data_space,
-                                                  symbol=symol,
-                                                  data_type=data_type)
-            self.assertEqual(key.make_key(data_entry),
-                             (data_space, symbol, data_type))
+    @parameterized.parameters((
+        data_entry_pb2.DataEntry.STOCK_DATA,
+        "IBM",
+        data_type_pb2.DataType.CLOSE_PRICE,
+    ), (data_entry_pb2.DataEntry.STOCK_METADATA, "BA",
+        data_type_pb2.DataType.OPEN_PRICE))
+    def test_make_key(self, data_space, symbol, data_type):
+        data_entry = data_entry_pb2.DataEntry(data_space=data_space,
+                                              symbol=symbol,
+                                              data_type=data_type)
+        self.assertEqual(key.make_key(data_entry),
+                         (data_space, symbol, data_type))
 
 
 if __name__ == '__main__':

--- a/xlab/data/store/mongo/store.py
+++ b/xlab/data/store/mongo/store.py
@@ -48,7 +48,10 @@ class MongoDataStore(interface.DataStore):
     def lookup(self,
                lookup_key: interface.LookupKey) -> data_entry_pb2.DataEntries:
         cursor = self._coll.find(self._get_filter(lookup_key))
-        return [self._parse(record) for record in cursor]
+        entries = [self._parse(record) for record in cursor]
+        result = data_entry_pb2.DataEntries()
+        result.entries.extend(entries)
+        return result
 
     def each(self, fn: Callable[[data_entry_pb2.DataEntry], None]):
         all_cursor = self._coll.find()
@@ -64,13 +67,13 @@ class MongoDataStore(interface.DataStore):
 
     def _get_filter(self, lookup_key: interface.LookupKey) -> Dict:
         res = {}
-        if lookup_key.data_space is not None:
+        if lookup_key.data_space:
             res['dataSpace'] = lookup_key.data_space
-        if lookup_key.symbol is not None:
+        if lookup_key.symbol:
             res['symbol'] = lookup_key.symbol
-        if lookup_key.data_type is not None:
+        if lookup_key.data_type:
             res['dataType'] = lookup_key.data_type
-        if lookup_key.timestamp is not None:
+        if lookup_key.timestamp:
             timestamp_proto = timestamp_pb2.Timestamp()
             timestamp_proto.FromSeconds(lookup_key.timestamp)
             res['timestamp'] = timestamp_proto.ToJsonString()

--- a/xlab/data/store/mongo/store_test.py
+++ b/xlab/data/store/mongo/store_test.py
@@ -5,10 +5,15 @@ import mongomock
 from xlab.data.store import impl_test_factory
 from xlab.data.store.mongo import store
 
+store_factory = lambda: store.MongoDataStore(mongomock.MongoClient())
 
-class MongoDataStoreTest(
-        impl_test_factory.create(
-            lambda: store.MongoDataStore(mongomock.MongoClient()))):
+
+class MongoDataStoreTest(impl_test_factory.create(store_factory)):
+    pass
+
+
+class MongoDataStoreParameterizedTest(
+        impl_test_factory.create_parameterized_test(store_factory)):
     pass
 
 

--- a/xlab/data/store/textproto/BUILD
+++ b/xlab/data/store/textproto/BUILD
@@ -9,6 +9,7 @@ py_library(
     srcs_version = "PY3",
     deps = [
         "//xlab/data/proto:data_entry_py_pb2",
+        "//xlab/data/proto:data_type_py_pb2",
         "//xlab/data/store:interface",
         "//xlab/data/store/in_memory",
         "//xlab/util/status:errors",

--- a/xlab/data/store/textproto/store.py
+++ b/xlab/data/store/textproto/store.py
@@ -5,7 +5,7 @@ from absl import flags
 from absl import logging
 from google.protobuf import text_format
 
-from xlab.data.proto import data_entry_pb2
+from xlab.data.proto import data_entry_pb2, data_type_pb2
 from xlab.data.store import interface, in_memory, key
 from xlab.util.status import errors
 
@@ -83,7 +83,7 @@ class TextProtoDataStore(interface.DataStore):
             self._data_store_directory,
             data_entry_pb2.DataEntry.DataSpace.Name(data_space),
             symbol,
-            data_type + '.textproto',
+            data_type_pb2.DataType.Enum.Name(data_type) + '.textproto',
         ])
 
     def _maybe_create_dir(self, filepath: str):

--- a/xlab/data/store/textproto/store_test.py
+++ b/xlab/data/store/textproto/store_test.py
@@ -1,13 +1,26 @@
+import shutil
+
 from absl.testing import absltest
 
 from xlab.data.store import impl_test_factory
 from xlab.data.store.textproto import store
 
+_TEST_STORE_DIR = '/tmp/xlab_bazel_store_test/'
+store_factory = lambda: store.TextProtoDataStore(data_store_directory=
+                                                 _TEST_STORE_DIR)
 
-class TextProtoDataStoreTest(
-        impl_test_factory.create(
-            lambda: store.TextProtoDataStore(data_store_directory='/tmp'))):
-    pass
+
+class TextProtoDataStoreTest(impl_test_factory.create(store_factory)):
+
+    def tearDown(self):
+        shutil.rmtree(_TEST_STORE_DIR)
+
+
+class TextProtoDataStoreParameterizedTest(
+        impl_test_factory.create_parameterized_test(store_factory)):
+
+    def tearDown(self):
+        shutil.rmtree(_TEST_STORE_DIR)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Major Changes:

- Add a DataType protobuf to specify data types as enum instead of string.

- Move `ParameterizedTest` to top level, as earlier they did not get run at all when buried in the regular TestCase. This also exposed multiple test failures and bugs that were corrected throughout

 Highlights of minor changes:

- `xlab/data/store/impl_test_factory.py` has a parameterized test where one of the arguments are tuple, and I had a single element tuple `(_DATA_ENTRY3)`, which were interpreted as a regular variable instead of tuple. It's now changed to `(get_data_entry_three(),)` with the trailing comma.

- `LookupKey` in `xlab/data/store/interface.py` is updated to use the `DataType.Enum`. Here we leverage the convention of [proto3 enum](https://developers.google.com/protocol-buffers/docs/proto3#enum), which always have 0 as unspecified value, and use [implicit boolean conversion]([https://google.github.io/styleguide/pyguide.html#214-truefalse-evaluations]) to determine if an Enum is set, instead of using `Optional`. 

- The `xlab/data/store/textproto/store_test.py` writes data to files. A cleanup step is added to `tearDown` to make sure the state is cleaned between each test runs.



