### PR TITLE
Port absl::Time to Python

### DIFF
--- a/xlab/base/BUILD
+++ b/xlab/base/BUILD
@@ -1,4 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@py_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//xlab:internal"])
 
@@ -6,4 +7,14 @@ py_library(
     name = "time",
     srcs = ["time.py"],
     srcs_version = "PY3",
+)
+
+py_test(
+    name = "time_test",
+    srcs = ["time_test.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":time",
+        requirement("absl-py"),
+    ],
 )

--- a/xlab/base/time.py
+++ b/xlab/base/time.py
@@ -1,5 +1,118 @@
-from typing import NewType
+import datetime
+import time
 
-# A practical precision for saving data points.
-# This also helps ignore loss of precision in various cases.
-Seconds = NewType('Seconds', int)
+
+# Time class follows the interface of https://github.com/abseil/abseil-cpp/blob/master/absl/time/time.h.
+class Time(int):
+
+    def __new__(cls, ns=0):
+        return super(Time, cls).__new__(cls, ns)
+
+    def __add__(self, other):
+        return self.__class__(super(Time, self).__add__(other))
+
+    def __sub__(self, other):
+        return self.__class__(super(Time, self).__sub__(other))
+
+    def __mul__(self, other):
+        return self.__class__(super(Time, self).__mul__(other))
+
+    def __truediv__(self, other):
+        return self.__class__(super(Time, self).__truediv__(other))
+
+    def __str__(self):
+        seconds, nanoseconds = divmod(self, 1e9)
+        return f"Seconds: {seconds}, Nanoseconds: {nanoseconds}"
+
+    def __repr__(self):
+        return f"Time({self})"
+
+
+Duration = Time
+
+
+def Now() -> Time:
+    return Time(time.time_ns())
+
+
+def UnixEpoch() -> Time:
+    return Time()
+
+
+# Return the RFC3339 Full representation of the time.
+def FormatTime(t: Time, tz: datetime.timezone = None) -> str:
+    if tz is None:
+        tz = datetime.timezone.utc
+    rfc3339_secs = time.strftime('%Y-%m-%dT%H:%M:%S', time.gmtime(int(t) / 1e9))
+    tz_offset = datetime.time(tzinfo=tz).strftime('%z')
+    # -0700 -> -07:00
+    tz_offset = ''.join((tz_offset[:3], ':', tz_offset[3:]))
+    return ''.join((rfc3339_secs, tz_offset))
+
+
+def ZeroDuration() -> Duration:
+    return Duration(0)
+
+
+def Nanoseconds(n: int) -> Duration:
+    return Duration(n)
+
+
+def Microseconds(n: int) -> Duration:
+    return Duration(n * 1e3)
+
+
+def Milliseconds(n: int) -> Duration:
+    return Duration(n * 1e6)
+
+
+def Seconds(n: int) -> Duration:
+    return Duration(n * 1e9)
+
+
+def Minutes(n: int) -> Duration:
+    return Duration(n * 1e9 * 60)
+
+
+def Hours(n: int) -> Duration:
+    return Duration(n * 1e9 * 60 * 60)
+
+
+def FromUnixNanos(nanos: int) -> Time:
+    return Time(nanos)
+
+
+def FromUnixMillis(millis: int) -> Time:
+    return Time(millis * 1e3)
+
+
+def FromUnixMicros(micros: int) -> Time:
+    return Time(micros * 1e6)
+
+
+def FromUnixSeconds(seconds: int) -> Time:
+    return Time(seconds * 1e9)
+
+
+def FromDatetime(dt: datetime.datetime) -> Time:
+    return Time(time.mktime(dt.timetuple()) * 1e9)
+
+
+def ToUnixNanos(t: Time) -> int:
+    return int(t)
+
+
+def ToUnixMillis(t: Time) -> int:
+    return int(t) / 1e3
+
+
+def ToUnixMicros(t: Time) -> int:
+    return int(t) / 1e6
+
+
+def ToUnixSeconds(time: Time) -> int:
+    return int(t) / 1e9
+
+
+def ToDatetime(t: Time) -> datetime.datetime:
+    return datetime.datetime.fromtimestamp(int(t) / 1e9)

--- a/xlab/base/time_test.py
+++ b/xlab/base/time_test.py
@@ -1,0 +1,119 @@
+import datetime
+
+from absl.testing import absltest
+
+from xlab.base import time
+
+
+# Based on: https://github.com/abseil/abseil-cpp/blob/master/absl/time/time_test.cc
+class TimeTest(absltest.TestCase):
+
+    def test_const_expr(self):
+        self.assertEqual(time.Time(), time.UnixEpoch())
+        self.assertEqual(time.Time(), time.FromUnixNanos(0))
+        self.assertEqual(time.Time(), time.FromUnixMillis(0))
+        self.assertEqual(time.Time(), time.FromUnixMicros(0))
+        self.assertEqual(time.Time(), time.FromUnixSeconds(0))
+
+    def test_unix_epoch(self):
+        epoch = time.FromDatetime(datetime.datetime(1970, 1, 1, 0, 0, 0))
+        self.assertEqual(epoch, time.UnixEpoch())
+        self.assertEqual(epoch - time.UnixEpoch(), time.ZeroDuration())
+
+    def test_add(self):
+        d = time.Nanoseconds(1)
+        t0 = time.Time()
+        t1 = t0 + d
+        self.assertEqual(d, t1 - t0)
+        self.assertEqual(-d, t0 - t1)
+        self.assertEqual(t0, t1 - d)
+
+        t = t0
+        self.assertEqual(t0, t)
+        t += d
+        self.assertEqual(t0 + d, t)
+        self.assertEqual(d, t - t0)
+        t -= d
+        self.assertEqual(t0, t)
+
+        # Tests overflow between subseconds and seconds.
+        t = time.UnixEpoch()
+        t += time.Milliseconds(500)
+        self.assertEqual(time.UnixEpoch() + time.Milliseconds(500), t)
+        t += time.Milliseconds(600)
+        self.assertEqual(time.UnixEpoch() + time.Milliseconds(1100), t)
+        t -= time.Milliseconds(600)
+        self.assertEqual(time.UnixEpoch() + time.Milliseconds(500), t)
+        t -= time.Milliseconds(500)
+        self.assertEqual(time.UnixEpoch(), t)
+
+    def test_relational_operators(self):
+        t1 = time.Nanoseconds(0)
+        t2 = time.Nanoseconds(1)
+        t3 = time.Nanoseconds(2)
+        self.assertTrue(time.Time() == t1)
+        self.assertTrue(t1 == t1)
+        self.assertTrue(t2 == t2)
+        self.assertTrue(t3 == t3)
+
+        self.assertTrue(t1 < t2)
+        self.assertTrue(t2 < t3)
+        self.assertTrue(t1 < t3)
+
+        self.assertTrue(t1 <= t1)
+        self.assertTrue(t1 <= t2)
+        self.assertTrue(t2 <= t2)
+        self.assertTrue(t2 <= t3)
+        self.assertTrue(t3 <= t3)
+        self.assertTrue(t1 <= t3)
+
+        self.assertTrue(t2 > t1)
+        self.assertTrue(t3 > t2)
+        self.assertTrue(t3 > t1)
+
+        self.assertTrue(t2 >= t2)
+        self.assertTrue(t2 >= t1)
+        self.assertTrue(t3 >= t3)
+        self.assertTrue(t3 >= t2)
+        self.assertTrue(t1 >= t1)
+        self.assertTrue(t3 >= t1)
+
+    def test_floor_conversion(self):
+        self.assertEqual(
+            1, time.ToUnixNanos(time.UnixEpoch() + time.Nanoseconds(3) / 2))
+        self.assertEqual(
+            1, time.ToUnixNanos(time.UnixEpoch() + time.Nanoseconds(1)))
+        self.assertEqual(
+            0, time.ToUnixNanos(time.UnixEpoch() + time.Nanoseconds(1) / 2))
+        self.assertEqual(
+            0, time.ToUnixNanos(time.UnixEpoch() + time.Nanoseconds(0)))
+        # NOTE: the following three assertions are different from time.Time,
+        # as nanoseconds is the ultimate precison here.
+        self.assertEqual(
+            0, time.ToUnixNanos(time.UnixEpoch() - time.Nanoseconds(1) / 2))
+        self.assertEqual(
+            -1, time.ToUnixNanos(time.UnixEpoch() - time.Nanoseconds(1)))
+        self.assertEqual(
+            -1, time.ToUnixNanos(time.UnixEpoch() - time.Nanoseconds(3) / 2))
+
+        self.assertEqual(
+            -500, time.ToUnixNanos(time.UnixEpoch() - time.Microseconds(1) / 2))
+        self.assertEqual(
+            -1000, time.ToUnixNanos(time.UnixEpoch() - time.Microseconds(1)))
+        self.assertEqual(
+            -1500,
+            time.ToUnixNanos(time.UnixEpoch() - time.Microseconds(3) / 2))
+
+    def test_format_time(self):
+        t = time.FromDatetime(datetime.datetime(2015, 2, 3, 4, 5, 6))
+        self.assertEqual("2015-02-03T04:05:06+00:00", time.FormatTime(t))
+        t = time.FromDatetime(datetime.datetime(2015, 2, 3, 4, 5))
+        self.assertEqual("2015-02-03T04:05:00+00:00", time.FormatTime(t))
+        t = time.FromDatetime(datetime.datetime(2015, 2, 3, 4))
+        self.assertEqual("2015-02-03T04:00:00+00:00", time.FormatTime(t))
+        t = time.FromDatetime(datetime.datetime(2015, 2, 3))
+        self.assertEqual("2015-02-03T00:00:00+00:00", time.FormatTime(t))
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/xlab/base/time_test.py
+++ b/xlab/base/time_test.py
@@ -87,7 +87,7 @@ class TimeTest(absltest.TestCase):
             0, time.ToUnixNanos(time.UnixEpoch() + time.Nanoseconds(1) / 2))
         self.assertEqual(
             0, time.ToUnixNanos(time.UnixEpoch() + time.Nanoseconds(0)))
-        # NOTE: the following three assertions are different from time.Time,
+        # NOTE: the following three assertions are different from absl::Time,
         # as nanoseconds is the ultimate precison here.
         self.assertEqual(
             0, time.ToUnixNanos(time.UnixEpoch() - time.Nanoseconds(1) / 2))

--- a/xlab/data/store/BUILD
+++ b/xlab/data/store/BUILD
@@ -31,6 +31,7 @@ py_library(
         ":store",
         "//xlab/data/proto:data_entry_py_pb2",
         "//xlab/data/proto:data_type_py_pb2",
+        "//xlab/net/proto:time_util",
         "//xlab/net/proto/testing:compare",
         "//xlab/net/proto/testing:parse",
         requirement("absl-py"),
@@ -47,6 +48,7 @@ py_library(
         "//xlab/base:time",
         "//xlab/data/proto:data_entry_py_pb2",
         "//xlab/data/proto:data_type_py_pb2",
+        "//xlab/net/proto:time_util",
     ],
 )
 

--- a/xlab/data/store/impl_test_factory.py
+++ b/xlab/data/store/impl_test_factory.py
@@ -4,11 +4,13 @@ import unittest
 from absl.testing import absltest, parameterized
 from google.protobuf import timestamp_pb2
 
-from xlab.base import time
 from xlab.data import store
 from xlab.data.store import key
-from xlab.data.proto import data_entry_pb2, data_type_pb2
-from xlab.net.proto.testing import compare, parse
+from xlab.data.proto import data_entry_pb2
+from xlab.data.proto import data_type_pb2
+from xlab.net.proto import time_util
+from xlab.net.proto.testing import compare
+from xlab.net.proto.testing import parse
 from xlab.util.status import errors
 
 StoreFactory = Callable[[], store.DataStore]
@@ -78,8 +80,8 @@ def create(impl_factory: StoreFactory) -> absltest.TestCase:
                     data_space=int(data_entry_pb2.DataEntry.STOCK_DATA),
                     symbol="SPY",
                     data_type=data_type_pb2.DataType.CLOSE_PRICE,
-                    timestamp=time.Seconds(
-                        timestamp_pb2.Timestamp(seconds=654321).ToSeconds()))
+                    timestamp=time_util.to_time(
+                        timestamp_pb2.Timestamp(seconds=654321)))
                 self._store.read(lookup_key)
 
         def test_each(self):

--- a/xlab/data/store/in_memory/BUILD
+++ b/xlab/data/store/in_memory/BUILD
@@ -20,6 +20,7 @@ py_library(
         "//xlab/data/proto:data_entry_py_pb2",
         "//xlab/data/store",
         "//xlab/data/store:key",
+        "//xlab/net/proto:time_util",
         "//xlab/util/status:errors",
     ],
 )

--- a/xlab/data/store/interface.py
+++ b/xlab/data/store/interface.py
@@ -20,7 +20,7 @@ class DataStore(abc.ABC):
         data_space: int = 0  # Prot Enum data_entry_pb2.DataEntry.DataSpace
         symbol: Optional[str] = None
         data_type: int = 0  # Proto Enum data_type_pb2.DataType.Enum
-        timestamp: Optional[time.Seconds] = None
+        timestamp: Optional[time.Time] = None
 
     # Read a single data entry by a key. If the data entry is not found, throw
     # an exception (instead of returns None).

--- a/xlab/data/store/key.py
+++ b/xlab/data/store/key.py
@@ -2,7 +2,9 @@ from typing import Tuple
 
 from xlab.base import time
 from xlab.data import store
-from xlab.data.proto import data_entry_pb2, data_type_pb2
+from xlab.data.proto import data_entry_pb2
+from xlab.data.proto import data_type_pb2
+from xlab.net.proto import time_util
 
 DataKey = Tuple[int,  # Prot Enum data_entry_pb2.DataEntry.DataSpace
                 str,  # symbol
@@ -35,5 +37,5 @@ def make_lookup_key(
     return store.DataStore.LookupKey(data_space=data_entry.data_space,
                                      symbol=data_entry.symbol,
                                      data_type=data_entry.data_type,
-                                     timestamp=time.Seconds(
-                                         data_entry.timestamp.ToSeconds()))
+                                     timestamp=time_util.to_time(
+                                         data_entry.timestamp))

--- a/xlab/data/store/mongo/BUILD
+++ b/xlab/data/store/mongo/BUILD
@@ -30,6 +30,7 @@ py_library(
         "//xlab/data/proto:data_entry_py_pb2",
         "//xlab/data/store",
         "//xlab/data/store:key",
+        "//xlab/net/proto:time_util",
         "//xlab/util/status:errors",
         requirement("pymongo"),
         requirement("protobuf"),

--- a/xlab/data/store/mongo/store.py
+++ b/xlab/data/store/mongo/store.py
@@ -1,6 +1,7 @@
 from typing import Callable, Dict, List, Tuple
 
-from google.protobuf import json_format, timestamp_pb2
+from google.protobuf import json_format
+from google.protobuf import timestamp_pb2
 import pymongo
 from pymongo import client_session
 
@@ -8,6 +9,7 @@ from xlab.data import store
 from xlab.data.proto import data_entry_pb2
 from xlab.data.store import key
 from xlab.data.store.mongo import db_client
+from xlab.net.proto import time_util
 from xlab.util.status import errors
 
 
@@ -77,7 +79,6 @@ class MongoDataStore(store.DataStore):
         if lookup_key.data_type:
             res['dataType'] = lookup_key.data_type
         if lookup_key.timestamp:
-            timestamp_proto = timestamp_pb2.Timestamp()
-            timestamp_proto.FromSeconds(lookup_key.timestamp)
-            res['timestamp'] = timestamp_proto.ToJsonString()
+            res['timestamp'] = time_util.from_time(
+                lookup_key.timestamp).ToJsonString()
         return res

--- a/xlab/net/proto/BUILD
+++ b/xlab/net/proto/BUILD
@@ -1,0 +1,14 @@
+load("@rules_python//python:defs.bzl", "py_library")
+load("@py_deps//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//xlab:internal"])
+
+py_library(
+    name = "time_util",
+    srcs = ["time_util.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//xlab/base:time",
+        requirement("protobuf"),
+    ],
+)

--- a/xlab/net/proto/time_util.py
+++ b/xlab/net/proto/time_util.py
@@ -1,0 +1,12 @@
+from xlab.base import time
+from google.protobuf import timestamp_pb2
+
+
+def to_time(pb: timestamp_pb2.Timestamp) -> time.Time:
+    return time.FromUnixNanos(pb.ToNanoseconds())
+
+
+def from_time(t: time.Time) -> timestamp_pb2.Timestamp:
+    pb = timestamp_pb2.Timestamp()
+    pb.FromNanoseconds(time.ToUnixNanos(t))
+    return pb


### PR DESCRIPTION
Create a `Time` class that has nanosecond precision (whereas `datetime.datetime` has a lower and platform-specific precision). (Well, time_ns actually still have a platform-specific precision but whatever).

The `Time` class has a number of constructors that are stolen from [the C++ absl::Time](https://github.com/chromium/chromium/blob/master/third_party/abseil-cpp/absl/time/time.h). This hopefully will make it simpler to work with time in the future code, e.g. when we compute X day moving averages and specify the timespan of a particular price data.