### PR TITLE
downgrade python version to 3.7 to allow working with beam

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,17 +23,17 @@ commands:
     description: Install Python
     steps:
       - run:
-          name: install Python 3.8
+          name: install Python 3.7
           command: |
             python3 --version
 
             apt-get install software-properties-common
             add-apt-repository --yes ppa:deadsnakes/ppa
             apt-get update
-            apt-get install --yes python3.8
-            apt-get install --yes python3.8-venv
+            apt-get install --yes python3.7
+            apt-get install --yes python3.7-venv
 
-            python3.8 -m venv .venv --without-pip
+            python3.7 -m venv .venv --without-pip
 
   # Initializes the CI environment by setting up common environment variables.
   init_environment:

--- a/.envrc
+++ b/.envrc
@@ -4,5 +4,4 @@ source secrets.rc
 
 # https://github.com/direnv/direnv/wiki/Python
 export VIRTUAL_ENV=.venv
-layout python-venv python3.8
-
+layout python-venv python3.7

--- a/BUILD
+++ b/BUILD
@@ -1,14 +1,14 @@
 load("@rules_python//python:defs.bzl", "py_runtime", "py_runtime_pair")
 
 py_runtime(
-    name = "python-3.8",
-    interpreter = ".venv/bin/python3.8",
+    name = "python-3.7",
+    interpreter = ".venv/bin/python3.7",
     python_version = "PY3",
 )
 
 py_runtime_pair(
     name = "py_runtime_pair",
-    py3_runtime = ":python-3.8",
+    py3_runtime = ":python-3.7",
 )
 
 toolchain(

--- a/xlab/data/calc/registry.py
+++ b/xlab/data/calc/registry.py
@@ -6,7 +6,7 @@ from xlab.data.proto import data_type_pb2
 from xlab.util.status import errors
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=None)
 def get_calc_producer(
         calc_type: data_type_pb2.DataType.Enum) -> calc.CalcProducer:
     try:


### PR DESCRIPTION
FYI I have to downgarde the python version from 3.8 to 3.7, as [Beam](https://beam.apache.org/) does not yet support python and I ran into issues installing beam with python 3.8: https://github.com/fastavro/fastavro/issues/427

To have the repo work with this change:
1. Remove the existing .venv directory: `rm -rf .venv`
2. Allow updated .envrc: `direnv allow`, which should detect that no virtualenv exists anymore, and recreate one with python 3.7