### PR TITLE
Add Beam Pipeline for performing calcs

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 absl-py>=0.9.0
+apache-beam>=2.20.0
 jupyter_http_over_ws==0.0.8
 mongomock>=3.19.0
 notebook>=6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,17 +5,26 @@
 #    pip-compile requirements.in
 #
 absl-py==0.9.0            # via -r requirements.in
+apache-beam==2.20.0       # via -r requirements.in
 appnope==0.1.0            # via ipykernel, ipython
 attrs==19.3.0             # via jsonschema
+avro-python3==1.9.2.1     # via apache-beam
 backcall==0.1.0           # via ipython
 bleach==3.1.4             # via nbconvert
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
+crcmod==1.7               # via apache-beam
 decorator==4.4.2          # via ipython, traitlets
 defusedxml==0.6.0         # via nbconvert
+dill==0.3.1.1             # via apache-beam
+docopt==0.6.2             # via hdfs
 entrypoints==0.3          # via nbconvert
+fastavro==0.21.24         # via apache-beam
+future==0.18.2            # via apache-beam
+grpcio==1.29.0            # via apache-beam
+hdfs==2.5.8               # via apache-beam
+httplib2==0.12.0          # via apache-beam, oauth2client
 idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via jsonschema
 ipykernel==5.2.1          # via notebook
 ipython-genutils==0.2.0   # via nbformat, notebook, traitlets
 ipython==7.13.0           # via ipykernel
@@ -27,38 +36,47 @@ jupyter-core==4.6.3       # via jupyter-client, nbconvert, nbformat, notebook
 jupyter_http_over_ws==0.0.8  # via -r requirements.in
 markupsafe==1.1.1         # via jinja2
 mistune==0.8.4            # via nbconvert
+mock==2.0.0               # via apache-beam
 mongomock==3.19.0         # via -r requirements.in
 nbconvert==5.6.1          # via notebook
 nbformat==5.0.6           # via nbconvert, notebook
 notebook==6.0.3           # via -r requirements.in, jupyter-http-over-ws
-numpy==1.18.3             # via pandas
+numpy==1.18.3             # via apache-beam, pandas, pyarrow
+oauth2client==3.0.0       # via apache-beam
 pandas==1.0.1             # via -r requirements.in
 pandocfilters==1.4.2      # via nbconvert
 parso==0.7.0              # via jedi
+pbr==5.4.5                # via mock
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
 prometheus-client==0.7.1  # via notebook
 prompt-toolkit==3.0.5     # via ipython
-protobuf==3.11.3          # via -r requirements.in
+protobuf==3.11.3          # via -r requirements.in, apache-beam
 ptyprocess==0.6.0         # via pexpect, terminado
+pyarrow==0.16.0           # via apache-beam
+pyasn1-modules==0.2.8     # via oauth2client
+pyasn1==0.4.8             # via oauth2client, pyasn1-modules, rsa
+pydot==1.4.1              # via apache-beam
 pygments==2.6.1           # via ipython, nbconvert
-pymongo==3.10.1           # via -r requirements.in
+pymongo==3.10.1           # via -r requirements.in, apache-beam
+pyparsing==2.4.7          # via pydot
 pyrsistent==0.16.0        # via jsonschema
-python-dateutil==2.8.1    # via jupyter-client, pandas
-pytz==2019.3              # via pandas
+python-dateutil==2.8.1    # via apache-beam, jupyter-client, pandas
+pytz==2019.3              # via apache-beam, pandas
 pyzmq==19.0.0             # via jupyter-client, notebook
-requests==2.23.0          # via -r requirements.in
+requests==2.23.0          # via -r requirements.in, hdfs
+rsa==4.0                  # via oauth2client
 send2trash==1.5.0         # via notebook
 sentinels==1.0.0          # via mongomock
-six==1.14.0               # via absl-py, bleach, jsonschema, jupyter-http-over-ws, mongomock, protobuf, pyrsistent, python-dateutil, traitlets
+six==1.14.0               # via absl-py, bleach, grpcio, hdfs, jsonschema, jupyter-http-over-ws, mock, mongomock, oauth2client, protobuf, pyarrow, pyrsistent, python-dateutil, traitlets
 terminado==0.8.3          # via notebook
 testpath==0.4.4           # via nbconvert
 tornado==6.0.4            # via ipykernel, jupyter-client, jupyter-http-over-ws, notebook, terminado
 traitlets==4.3.3          # via ipykernel, ipython, jupyter-client, jupyter-core, nbconvert, nbformat, notebook
+typing-extensions==3.7.4.2  # via apache-beam
 urllib3==1.25.9           # via requests
 wcwidth==0.1.9            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
-zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/xlab/data/calc/input_util.py
+++ b/xlab/data/calc/input_util.py
@@ -1,6 +1,6 @@
 import functools
 import itertools
-from typing import Optional
+from typing import List, Optional, Tuple
 
 from xlab.base import time
 from xlab.data import calc
@@ -22,6 +22,27 @@ def is_same_input_shape(input: Optional[DataEntry],
         time_util.to_time(input.timestamp) == time_util.to_time(
             input_shape.timestamp),
     ])
+
+
+def _make_input_shape_key(data_entry: DataEntry) -> Tuple[int, time.Time]:
+    return (data_entry.data_type, time_util.to_time(data_entry.timestamp))
+
+
+# Sort a list of data entries with no assumed ordering into the given inputs
+# shape. Raises if such sorting cannot produce the expected inputs shape.
+def sort_to_inputs_shape(data_entries: List[DataEntry],
+                         inputs_shape: calc.CalcInputs) -> calc.CalcInputs:
+    data_entry_dict = {_make_input_shape_key(d): d for d in data_entries}
+    try:
+        return [
+            data_entry_dict[_make_input_shape_key(input_shape)]
+            for input_shape in inputs_shape
+        ]
+    except KeyError as e:
+        nl = '\n'
+        raise errors.InvalidArgumentError(
+            f'Cannot sort inputs to the given shape: {e}{nl}'
+            f'Inputs are: {nl.join(str(d) for d in data_entries)}')
 
 
 def are_for_stock(inputs: calc.CalcInputs) -> str:

--- a/xlab/data/calc/input_util_test.py
+++ b/xlab/data/calc/input_util_test.py
@@ -76,6 +76,22 @@ class CalcInputUtilTest(absltest.TestCase):
               seconds: 2234567
             }"""))
 
+    def test_sort_to_inputs_shape(self):
+        inputs = reversed(get_valid_inputs())
+        got = input_util.sort_to_inputs_shape(inputs, get_input_shapes())
+        compare.assertProtoSequencesEqual(self, got, get_valid_inputs())
+
+    def test_not_enough_data_to_sort_to_inputs_shape(self):
+        inputs = get_valid_inputs()[:1]
+        with self.assertRaisesRegex(errors.InvalidArgumentError,
+                                    'Cannot sort inputs to the given shape'):
+            input_util.sort_to_inputs_shape(inputs, get_input_shapes())
+
+    def test_more_data_than_needed_to_sort_to_inputs_shape(self):
+        inputs = [*reversed(get_valid_inputs()), *get_valid_inputs()]
+        got = input_util.sort_to_inputs_shape(inputs, get_input_shapes())
+        compare.assertProtoSequencesEqual(self, got, get_valid_inputs())
+
     def test_valid_inputs_do_not_raise(self):
         inputs = get_valid_inputs()
         input_util.validate_inputs(inputs, get_input_shapes())

--- a/xlab/data/calc/interface.py
+++ b/xlab/data/calc/interface.py
@@ -35,16 +35,24 @@ class CalcProducer(abc.ABC):
     def time_spec(self) -> CalcTimeSpecs:
         pass
 
-    # Compute the calc for a given security at a given timestamp.
+    # Computes the calc for a given security at a given timestamp.
     @abc.abstractmethod
     def calculate(self, inputs: CalcInputs) -> DataEntry:
         pass
 
-    # List all input shapes that can be used to produce this type of calc.
-    # An input shape is a sequence of DataEntry with specific data type,
-    # symbol, and timestamps.
+    # An input shape is a sequence of DataEntry(s) with specific data type and
+    # timestamps.
+    # Returns the input shape that can be used to recursively produce this type
+    # of calc, i.e. using the same calc from a prior time period / point. Empty
+    # if this calc cannot be done recursively.
     @abc.abstractmethod
-    def accepted_inputs_shapes(self, t: time.Time) -> Tuple[CalcInputs, ...]:
+    def recursive_inputs_shape(self, t: time.Time) -> RecursiveInputs:
+        pass
+
+    # Returns the input shapes that can be used to produce this type of calc
+    # using source data.
+    @abc.abstractmethod
+    def source_inputs_shape(self, t: time.Time) -> SourceInputs:
         pass
 
 

--- a/xlab/data/calc/producers/ema.py
+++ b/xlab/data/calc/producers/ema.py
@@ -34,11 +34,10 @@ class EmaProducer:
         symbol = input_util.are_for_stock(inputs)
         t = time_util.to_time(inputs[-1].timestamp)
         try:
-            input_util.validate_inputs(inputs, self._recursive_input_shape(t))
+            input_util.validate_inputs(inputs, self.recursive_inputs_shape(t))
             ema = self._recur(inputs)
         except errors.InvalidArgumentError:
-            input_util.validate_inputs(inputs,
-                                       self._initial_source_input_shape(t))
+            input_util.validate_inputs(inputs, self.source_inputs_shape(t))
             ema = self._initial(inputs)
         except errors.InvalidArgumentError as e:
             raise e
@@ -63,17 +62,12 @@ class EmaProducer:
         return (SMOOTHING_FACTOR / (num_periods + 1) * inputs[1].value \
           + (num_periods + 1 - SMOOTHING_FACTOR) / (num_periods + 1) * inputs[0].value)
 
-    def accepted_input_shapes(self,
-                              t: time.Time) -> Tuple[calc.CalcInputs, ...]:
-        return (self._recursive_input_shape(t),
-                self._initial_source_input_shape(t))
-
-    def _recursive_input_shape(self, t: time.Time) -> calc.CalcInputs:
+    def recursive_inputs_shape(self, t: time.Time) -> calc.RecursiveInputs:
         return input_util.recursive_inputs_shape(self.calc_type,
                                                  self._source_calc, t,
                                                  self.time_specs)
 
-    def _initial_source_input_shape(self, t: time.Time) -> calc.CalcInputs:
+    def source_inputs_shape(self, t: time.Time) -> calc.SourceInputs:
         return input_util.series_source_inputs_shape(self._source_calc, t,
                                                      self.time_specs)
 

--- a/xlab/data/pipeline/BUILD
+++ b/xlab/data/pipeline/BUILD
@@ -1,0 +1,36 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@py_deps//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//xlab:internal"])
+
+py_library(
+    name = "produce_calc_fn",
+    srcs = ["produce_calc_fn.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//xlab/base:time",
+        "//xlab/data/calc",
+        "//xlab/data/calc:input_util",
+        "//xlab/data/calc:registry",
+        "//xlab/data/proto:data_entry_py_pb2",
+        "//xlab/data/proto:data_type_py_pb2",
+        "//xlab/util/status:errors",
+        requirement("absl-py"),
+        requirement("apache-beam"),
+    ],
+)
+
+py_test(
+    name = "produce_calc_fn_test",
+    srcs = ["produce_calc_fn_test.py"],
+    deps = [
+        ":produce_calc_fn",
+        "//xlab/base:time",
+        "//xlab/data/proto:data_entry_py_pb2",
+        "//xlab/data/proto:data_type_py_pb2",
+        "//xlab/net/proto:time_util",
+        "//xlab/net/proto/testing:parse",
+        requirement("absl-py"),
+        requirement("apache-beam"),
+    ],
+)

--- a/xlab/data/pipeline/produce_calc_fn.py
+++ b/xlab/data/pipeline/produce_calc_fn.py
@@ -1,0 +1,66 @@
+from typing import Generator, List
+
+from absl import logging
+import apache_beam as beam
+from apache_beam.transforms import ptransform
+
+from xlab.base import time
+from xlab.data import calc
+from xlab.data.calc import input_util
+from xlab.data.calc import registry as calc_registry
+from xlab.data.proto import data_entry_pb2
+from xlab.data.proto import data_type_pb2
+from xlab.util.status import errors
+
+DataEntry = data_entry_pb2.DataEntry
+DataType = data_type_pb2.DataType
+PCollection = beam.pvalue.PCollection
+
+
+@ptransform.ptransform_fn
+def produce_initial_calc_fn(inputs: PCollection, calc_type: DataType,
+                            t: time.Time) -> PCollection:
+    calc_producer = calc_registry.get_calc_producer(calc_type)
+    inputs_shape = calc_producer.source_inputs_shape(t)
+    return _produce_calc_fn(inputs, calc_producer, inputs_shape)
+
+
+@ptransform.ptransform_fn
+def produce_recursive_calc_fn(inputs: PCollection, calc_type: DataType,
+                              t: time.Time) -> PCollection:
+    calc_producer = calc_registry.get_calc_producer(calc_type)
+    inputs_shape = calc_producer.recursive_inputs_shape(t)
+    return _produce_calc_fn(inputs, calc_producer, inputs_shape)
+
+
+# Note this convenience function is not decorated with @ptransform_fn.
+def _produce_calc_fn(inputs: PCollection, calc_producer: calc.CalcProducer,
+                     inputs_shape: calc.CalcInputs) -> PCollection:
+    return (inputs \
+      | 'FilterByInputsShape' >> beam.Filter(filter_by_input_shapes,
+                                             inputs_shape) \
+      | 'WithSymbolAsKey' >> beam.Map(lambda d: (d.symbol, d)) \
+      | 'GroupByKey' >> beam.GroupByKey() \
+      | 'Values' >> beam.Values() \
+      | 'PerformCalc' >> beam.FlatMap(perform_calc, inputs_shape,
+                                      calc_producer))
+
+
+def filter_by_input_shapes(data_entry: DataEntry,
+                           inputs_shape: calc.CalcInputs) -> bool:
+    return any([
+        input_util.is_same_input_shape(data_entry, input_shape)
+        for input_shape in inputs_shape
+    ])
+
+
+def perform_calc(
+        data_entries: List[DataEntry], inputs_shape: calc.CalcInputs,
+        calc_producer: calc.CalcProducer) -> Generator[DataEntry, None, None]:
+    try:
+        calc_inputs = input_util.sort_to_inputs_shape(data_entries,
+                                                      inputs_shape)
+        result = calc_producer.calculate(calc_inputs)
+        yield result
+    except errors.InvalidArgumentError as e:
+        logging.error(f'Error when trying to perform calc: {e}')

--- a/xlab/data/pipeline/produce_calc_fn_test.py
+++ b/xlab/data/pipeline/produce_calc_fn_test.py
@@ -1,0 +1,191 @@
+import datetime
+import random
+from typing import List
+
+from absl.testing import absltest
+import apache_beam as beam
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
+
+from xlab.base import time
+from xlab.data.pipeline import produce_calc_fn
+from xlab.data.proto import data_entry_pb2
+from xlab.data.proto import data_type_pb2
+from xlab.net.proto import time_util
+from xlab.net.proto.testing import parse
+
+DataEntry = data_entry_pb2.DataEntry
+DataType = data_type_pb2.DataType
+produce_initial_calc_fn = produce_calc_fn.produce_initial_calc_fn
+produce_recursive_calc_fn = produce_calc_fn.produce_recursive_calc_fn
+
+
+def _make_close_price(symbol: str, value: float, t: time.Time) -> DataEntry:
+    return DataEntry(
+        symbol=symbol,
+        data_space=DataEntry.STOCK_DATA,
+        data_type=data_type_pb2.DataType.CLOSE_PRICE,
+        value=value,
+        timestamp=time_util.from_time(t),
+    )
+
+
+def get_close_prices_for_ema20(t: time.Time, symbol: str) -> List[DataEntry]:
+    # INTC 2019-12-03 to 2019-12-31
+    price_data = [
+        56.07, 56.02, 56.08, 56.81, 56.53, 56.59, 57.07, 57.55, 57.79, 57.70,
+        57.23, 57.17, 57.96, 58.95, 59.23, 59.41, 59.82, 60.08, 59.62, 59.85,
+    ]  # yapf: disable
+
+    close_prices = [
+        _make_close_price(symbol, value, t - (19 - idx) * time.Hours(24))
+        for idx, value in enumerate(price_data)
+    ]
+    random.shuffle(close_prices)
+    return close_prices
+
+
+def get_recursive_inputs_for_ema20(t: time.Time,
+                                   symbol: str) -> List[DataEntry]:
+    return [
+        DataEntry(
+            symbol=symbol,
+            data_space=DataEntry.STOCK_DATA,
+            data_type=DataType.EMA_20D,
+            value=58.31,
+            timestamp=time_util.from_time(t - time.Hours(24)),
+        ),
+        _make_close_price(symbol, 59.85, t)
+    ]
+
+
+def expected_ema20d_test() -> DataEntry:
+    return parse.parse_test_proto(
+        """
+        symbol: "TEST"
+        data_space: STOCK_DATA
+        data_type: EMA_20D
+        value: 58.255796513052346
+        timestamp {
+            seconds: 1577750400
+        }""", DataEntry)
+
+
+def expected_recursive_ema20d_test() -> DataEntry:
+    return parse.parse_test_proto(
+        """
+        symbol: "TEST"
+        data_space: STOCK_DATA
+        data_type: EMA_20D
+        value: 58.45666666666667
+        timestamp {
+            seconds: 1577750400
+        }""", DataEntry)
+
+
+class ProduceCalcFnTest(absltest.TestCase):
+
+    def test_produce_initial_calc_fn_with_no_input(self):
+        t = time.FromUnixSeconds(12345)
+        inputs = []
+        with TestPipeline() as p:
+            out = (p \
+                | beam.Create(inputs) \
+                | produce_initial_calc_fn(DataType.EMA_20D, t))
+
+            assert_that(out, equal_to([]))
+
+    def test_produce_initial_calc_fn(self):
+        t = time.FromDatetime(datetime.datetime(2019, 12, 31))
+        inputs = get_close_prices_for_ema20(t, 'TEST')
+        with TestPipeline() as p:
+            out = (p \
+                | beam.Create(inputs) \
+                | produce_initial_calc_fn(DataType.EMA_20D, t))
+
+            assert_that(out, equal_to([expected_ema20d_test()]))
+
+    def test_produce_initial_calc_fn_ignores_irrelevant_data(self):
+        t = time.FromDatetime(datetime.datetime(2019, 12, 31))
+        inputs = get_close_prices_for_ema20(t, 'TEST')
+        inputs.append(_make_close_price('X', 123.45, t))
+        with TestPipeline() as p:
+            out = (p \
+                | beam.Create(inputs) \
+                | produce_initial_calc_fn(DataType.EMA_20D, t))
+
+            assert_that(out, equal_to([expected_ema20d_test()]))
+
+    def test_produce_initial_calc_fn_not_enough_data(self):
+        t = time.FromDatetime(datetime.datetime(2019, 12, 31))
+        inputs = get_close_prices_for_ema20(t, 'TEST')[:19]
+        with TestPipeline() as p:
+            out = (p \
+                | beam.Create(inputs) \
+                | produce_initial_calc_fn(DataType.EMA_20D, t))
+
+            assert_that(out, equal_to([]))
+
+    def test_produce_initial_calc_fn_multiple_symbols(self):
+        t = time.FromDatetime(datetime.datetime(2019, 12, 31))
+        inputs = [
+            *get_close_prices_for_ema20(t, 'TEST'),
+            *get_close_prices_for_ema20(t, 'IBM')
+        ]
+        with TestPipeline() as p:
+            out = (p \
+                | beam.Create(inputs) \
+                | produce_initial_calc_fn(DataType.EMA_20D, t))
+
+            assert_that(
+                out,
+                equal_to([
+                    expected_ema20d_test(),
+                    parse.parse_test_proto(
+                        """
+                        symbol: "IBM"
+                        data_space: STOCK_DATA
+                        data_type: EMA_20D
+                        value: 58.255796513052346
+                        timestamp {
+                            seconds: 1577750400
+                        }""", DataEntry)
+                ]))
+
+    def test_produce_recursive_calc_fn(self):
+        t = time.FromDatetime(datetime.datetime(2019, 12, 31))
+        inputs = get_recursive_inputs_for_ema20(t, 'TEST')
+        with TestPipeline() as p:
+            out = (p \
+                | beam.Create(inputs) \
+                | produce_recursive_calc_fn(DataType.EMA_20D, t))
+
+            assert_that(out, equal_to([expected_recursive_ema20d_test()]))
+
+    def test_produce_recursive_calc_fn_with_swapped_inputs(self):
+        t = time.FromDatetime(datetime.datetime(2019, 12, 31))
+        inputs = reversed(get_recursive_inputs_for_ema20(t, 'TEST'))
+        with TestPipeline() as p:
+            out = (p \
+                | beam.Create(inputs) \
+                | produce_recursive_calc_fn(DataType.EMA_20D, t))
+
+            assert_that(out, equal_to([expected_recursive_ema20d_test()]))
+
+    def test_produce_recursive_calc_fn_with_extra_data(self):
+        t = time.FromDatetime(datetime.datetime(2019, 12, 31))
+        inputs = [
+            *get_recursive_inputs_for_ema20(t, 'TEST'),
+            *get_close_prices_for_ema20(t, 'IBM')
+        ]
+        with TestPipeline() as p:
+            out = (p \
+                | beam.Create(inputs) \
+                | produce_recursive_calc_fn(DataType.EMA_20D, t))
+
+            assert_that(out, equal_to([expected_recursive_ema20d_test()]))
+
+
+if __name__ == '__main__':
+    absltest.main()


### PR DESCRIPTION
Initial Beam PR to introduce Beam and add beam_fn to perform the calcs.

Refactored inputs related calc logic to make them to friendly to work with from the pipeline's perspective, i.e. specify out source inputs and recursive inputs as separate methods.

TODO:
1. Add main programs for pipeline
2. Refactor test helper functions into test util libraries
3. Maybe use matchers for tests, as they are now introduced by the beam tests