### PR TITLE
Use CivilTime, an timezone agnostic datetime for date

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ jupyter_http_over_ws==0.0.8
 mongomock>=3.19.0
 notebook>=6.0.0
 pandas==1.0.1
+pendulum>=2.1.0
 protobuf==3.11.3
 pymongo>=3.10.0
 requests==2.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ grpcio==1.29.0            # via apache-beam
 hdfs==2.5.8               # via apache-beam
 httplib2==0.12.0          # via apache-beam, oauth2client
 idna==2.9                 # via requests
+importlib-metadata==1.6.0  # via jsonschema
 ipykernel==5.2.1          # via notebook
 ipython-genutils==0.2.0   # via nbformat, notebook, traitlets
 ipython==7.13.0           # via ipykernel
@@ -47,6 +48,7 @@ pandas==1.0.1             # via -r requirements.in
 pandocfilters==1.4.2      # via nbconvert
 parso==0.7.0              # via jedi
 pbr==5.4.5                # via mock
+pendulum==2.1.0           # via -r requirements.in
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
 prometheus-client==0.7.1  # via notebook
@@ -61,8 +63,9 @@ pygments==2.6.1           # via ipython, nbconvert
 pymongo==3.10.1           # via -r requirements.in, apache-beam
 pyparsing==2.4.7          # via pydot
 pyrsistent==0.16.0        # via jsonschema
-python-dateutil==2.8.1    # via apache-beam, jupyter-client, pandas
+python-dateutil==2.8.1    # via apache-beam, jupyter-client, pandas, pendulum
 pytz==2019.3              # via apache-beam, pandas
+pytzdata==2019.3          # via pendulum
 pyzmq==19.0.0             # via jupyter-client, notebook
 requests==2.23.0          # via -r requirements.in, hdfs
 rsa==4.0                  # via oauth2client
@@ -77,6 +80,7 @@ typing-extensions==3.7.4.2  # via apache-beam
 urllib3==1.25.9           # via requests
 wcwidth==0.1.9            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/xlab/base/BUILD
+++ b/xlab/base/BUILD
@@ -7,6 +7,9 @@ py_library(
     name = "time",
     srcs = ["time.py"],
     srcs_version = "PY3",
+    deps = [
+        requirement("pendulum"),
+    ],
 )
 
 py_test(

--- a/xlab/base/time_test.py
+++ b/xlab/base/time_test.py
@@ -1,5 +1,3 @@
-import datetime
-
 from absl.testing import absltest
 
 from xlab.base import time
@@ -16,7 +14,7 @@ class TimeTest(absltest.TestCase):
         self.assertEqual(time.Time(), time.FromUnixSeconds(0))
 
     def test_unix_epoch(self):
-        epoch = time.FromDatetime(datetime.datetime(1970, 1, 1, 0, 0, 0))
+        epoch = time.FromCivil(time.CivilTime(1970, 1, 1, 0, 0, 0))
         self.assertEqual(epoch, time.UnixEpoch())
         self.assertEqual(epoch - time.UnixEpoch(), time.ZeroDuration())
 
@@ -104,17 +102,169 @@ class TimeTest(absltest.TestCase):
             -1500,
             time.ToUnixNanos(time.UnixEpoch() - time.Microseconds(3) / 2))
 
-    def test_format_time(self):
-        t = time.FromDatetime(datetime.datetime(2015, 2, 3, 4, 5, 6))
+    def _test_conversion_round_trip(self, source, _from, to):
+        self.assertEqual(to(_from(source)), source)
+
+    def test_round_trip_time_conversion(self):
+        self._test_conversion_round_trip(-1, time.FromUnixNanos,
+                                         time.ToUnixNanos)
+        self._test_conversion_round_trip(0, time.FromUnixNanos,
+                                         time.ToUnixNanos)
+        self._test_conversion_round_trip(1, time.FromUnixNanos,
+                                         time.ToUnixNanos)
+        self._test_conversion_round_trip(time.GetCurrentTimeNanos(),
+                                         time.FromUnixNanos, time.ToUnixNanos)
+
+        self._test_conversion_round_trip(-1, time.FromUnixMillis,
+                                         time.ToUnixMillis)
+        self._test_conversion_round_trip(0, time.FromUnixMillis,
+                                         time.ToUnixMillis)
+        self._test_conversion_round_trip(1, time.FromUnixMillis,
+                                         time.ToUnixMillis)
+        self._test_conversion_round_trip(time.GetCurrentTimeNanos() / 1e3,
+                                         time.FromUnixMillis, time.ToUnixMillis)
+
+        self._test_conversion_round_trip(-1, time.FromUnixMicros,
+                                         time.ToUnixMicros)
+        self._test_conversion_round_trip(0, time.FromUnixMicros,
+                                         time.ToUnixMicros)
+        self._test_conversion_round_trip(1, time.FromUnixMicros,
+                                         time.ToUnixMicros)
+        self._test_conversion_round_trip(time.GetCurrentTimeNanos() / 1e6,
+                                         time.FromUnixMicros, time.ToUnixMicros)
+
+        self._test_conversion_round_trip(-1, time.FromUnixSeconds,
+                                         time.ToUnixSeconds)
+        self._test_conversion_round_trip(0, time.FromUnixSeconds,
+                                         time.ToUnixSeconds)
+        self._test_conversion_round_trip(1, time.FromUnixSeconds,
+                                         time.ToUnixSeconds)
+        self._test_conversion_round_trip(time.GetCurrentTimeNanos() / 1e9,
+                                         time.FromUnixSeconds,
+                                         time.ToUnixSeconds)
+
+    def _test_relational(self, older, younger):
+        self.assertFalse(older < older)
+        self.assertFalse(older > older)
+        self.assertTrue(older >= older)
+        self.assertTrue(older <= older)
+        self.assertFalse(younger < younger)
+        self.assertFalse(younger > younger)
+        self.assertTrue(younger >= younger)
+        self.assertTrue(younger <= younger)
+        self.assertEqual(older, older)
+        self.assertNotEqual(older, younger)
+        self.assertLess(older, younger)
+        self.assertLessEqual(older, younger)
+        self.assertGreater(younger, older)
+        self.assertGreaterEqual(younger, older)
+
+    def test_civil_time_relations(self):
+        self._test_relational(time.CivilTime(2014, 1, 1, 0, 0, 0),
+                              time.CivilTime(2015, 1, 1, 0, 0, 0))
+        self._test_relational(time.CivilTime(2014, 1, 1, 0, 0, 0),
+                              time.CivilTime(2014, 2, 1, 0, 0, 0))
+        self._test_relational(time.CivilTime(2014, 1, 1, 0, 0, 0),
+                              time.CivilTime(2014, 1, 2, 0, 0, 0))
+        self._test_relational(time.CivilTime(2014, 1, 1, 0, 0, 0),
+                              time.CivilTime(2014, 1, 1, 1, 0, 0))
+        self._test_relational(time.CivilTime(2014, 1, 1, 1, 0, 0),
+                              time.CivilTime(2014, 1, 1, 1, 1, 0))
+        self._test_relational(time.CivilTime(2014, 1, 1, 1, 1, 0),
+                              time.CivilTime(2014, 1, 1, 1, 1, 1))
+
+        self._test_relational(time.CivilTime(2014, 1, 1),
+                              time.CivilTime(2014, 1, 1, 1, 1))
+        self._test_relational(time.CivilTime(2014, 1, 1),
+                              time.CivilTime(2014, 2, 1))
+
+    def test_timezone_conversion(self):
+        est: time.Timezone = time.timezone('US/Eastern')
+        fmt = '%a, %e %b %Y %H:%M:%S %z (%Z)'
+
+        # A non-transition where the civil time is unique.
+        nov01 = time.CivilTime(2013, 11, 1, 8, 30, 0)
+        nov01_t = time.FromCivil(nov01, est)
+        self.assertEqual("Fri,  1 Nov 2013 08:30:00 -0400 (EDT)",
+                         time.FormatTime(nov01_t, est, fmt))
+
+        # A Spring DST transition, when there is a gap in civil time
+        # and we prefer the later of the possible interpretations of a
+        # non-existent time.
+        mar13 = time.CivilTime(2011, 3, 13, 2, 15, 0)
+        mar_t = time.FromCivil(mar13, est)
+        self.assertEqual("Sun, 13 Mar 2011 03:15:00 -0400 (EDT)",
+                         time.FormatTime(mar_t, est, fmt))
+
+        # A Fall DST transition, when civil times are repeated and
+        # we prefer the earlier of the possible interpretations of an
+        # ambiguous time.
+        nov06 = time.CivilTime(2011, 11, 6, 1, 15, 0)
+        nov_t = time.FromCivil(nov06, est)
+        self.assertEqual("Sun,  6 Nov 2011 01:15:00 -0400 (EDT)",
+                         time.FormatTime(nov_t, est, fmt))
+
+        # Check that (time_t) -1 is handled correctly.
+        minus1 = time.CivilTime(1969, 12, 31, 18, 59, 59)
+        minus1_t = time.FromCivil(minus1, est)
+        self.assertEqual("Wed, 31 Dec 1969 18:59:59 -0500 (EST)",
+                         time.FormatTime(minus1_t, est, fmt))
+        self.assertEqual("Wed, 31 Dec 1969 23:59:59 +0000 (UTC)",
+                         time.FormatTime(minus1_t, time.UTC, fmt))
+
+    def test_from_civil(self):
+        fmt = "%a, %e %b %Y %H:%M:%S %z (%Z)"
+        # Check that we're counting leap years correctly.
+        t = time.FromCivil(time.CivilTime(1900, 2, 28, 23, 59, 59), time.UTC)
+        self.assertEqual("Wed, 28 Feb 1900 23:59:59 +0000 (UTC)",
+                         time.FormatTime(t, time.UTC, fmt))
+        t = time.FromCivil(time.CivilTime(1900, 3, 1, 0, 0, 0), time.UTC)
+        self.assertEqual("Thu,  1 Mar 1900 00:00:00 +0000 (UTC)",
+                         time.FormatTime(t, time.UTC, fmt))
+        t = time.FromCivil(time.CivilTime(2000, 2, 29, 23, 59, 59), time.UTC)
+        self.assertEqual("Tue, 29 Feb 2000 23:59:59 +0000 (UTC)",
+                         time.FormatTime(t, time.UTC, fmt))
+        t = time.FromCivil(time.CivilTime(2000, 3, 1, 0, 0, 0), time.UTC)
+        self.assertEqual("Wed,  1 Mar 2000 00:00:00 +0000 (UTC)",
+                         time.FormatTime(t, time.UTC, fmt))
+
+    def test_default_time_format(self):
+        t = time.FromCivil(time.CivilTime(2015, 2, 3, 4, 5, 6))
         self.assertEqual("2015-02-03T04:05:06+00:00", time.FormatTime(t))
-        t = time.FromDatetime(datetime.datetime(2015, 2, 3, 4, 5))
+        t = time.FromCivil(time.CivilTime(2015, 2, 3, 4, 5))
         self.assertEqual("2015-02-03T04:05:00+00:00", time.FormatTime(t))
-        t = time.FromDatetime(datetime.datetime(2015, 2, 3, 4))
+        t = time.FromCivil(time.CivilTime(2015, 2, 3, 4))
         self.assertEqual("2015-02-03T04:00:00+00:00", time.FormatTime(t))
-        t = time.FromDatetime(datetime.datetime(2015, 2, 3))
+        t = time.FromCivil(time.CivilTime(2015, 2, 3))
         self.assertEqual("2015-02-03T00:00:00+00:00", time.FormatTime(t))
-        t = time.FromDate(datetime.date(2015, 2, 3))
-        self.assertEqual("2015-02-03T00:00:00+00:00", time.FormatTime(t))
+
+    def test_format_civil_time(self):
+        ct = time.CivilTime(1970, 1, 1)
+        self.assertEqual("1970-01-01T00:00:00", time.FormatCivilTime(ct))
+        ct = time.CivilTime(2015, 1, 2, 3, 4, 5)
+        self.assertEqual("2015-01-02T03:04:05", time.FormatCivilTime(ct))
+
+        ct = time.ToCivil(time.Time(1234567890 * 1e9))
+        self.assertEqual("2009-02-13T23:31:30", time.FormatCivilTime(ct))
+        est: time.Timezone = time.timezone('US/Eastern')
+        ct = time.ToCivil(time.Time(1234567890 * 1e9), est)
+        self.assertEqual("2009-02-13T18:31:30", time.FormatCivilTime(ct))
+
+    def test_parse_civil_time(self):
+        self.assertEqual(time.CivilTime(2015, 1, 2, 3, 4, 5),
+                         time.ParseCivilTime("2015-01-02T03:04:05"))
+        self.assertEqual(time.CivilTime(2015, 1, 2, 3, 4),
+                         time.ParseCivilTime("2015-01-02T03:04:00"))
+        self.assertEqual(time.CivilTime(2015, 1, 2, 3),
+                         time.ParseCivilTime("2015-01-02T03:00:00"))
+        self.assertEqual(time.CivilTime(2015, 1, 2, 3),
+                         time.ParseCivilTime("2015-01-02T03:00"))
+        self.assertEqual(time.CivilTime(2015, 1, 2),
+                         time.ParseCivilTime("2015-01-02T00:00:00"))
+        self.assertEqual(time.CivilTime(2015, 1, 2),
+                         time.ParseCivilTime("2015-01-02T00:00"))
+        self.assertEqual(time.CivilTime(2015, 1, 2),
+                         time.ParseCivilTime("2015-01-02"))
 
 
 if __name__ == '__main__':

--- a/xlab/data/calc/input_util.py
+++ b/xlab/data/calc/input_util.py
@@ -70,9 +70,12 @@ def series_source_inputs_shape(
     # TODO: right now this is still no properly generalized. For time span
     # longer than a day, they should all work. However for day and shorter span,
     # they need to be checked against trading days and trading hours.
+    # NOTE: both FromCivil and ToCivil assumes UTC, which later might
+    # be updated to take into account the exchange timezone of a
+    # security.
     timestamps = [
-        time.FromDate(day) for day in trading_days.get_last_n(
-            time.ToDate(t), time_spec.num_periods)
+        time.FromCivil(day) for day in trading_days.get_last_n(
+            time.ToCivil(t), time_spec.num_periods)
     ]
     return [
         DataEntry(

--- a/xlab/data/calc/producers/ema_test.py
+++ b/xlab/data/calc/producers/ema_test.py
@@ -1,5 +1,3 @@
-import datetime
-
 from absl.testing import absltest
 
 from xlab.base import time
@@ -27,9 +25,9 @@ def _make_close_price(value: float, t: time.Time) -> DataEntry:
 class EmaCalculationTest(absltest.TestCase):
 
     def test_ema_20_for_constant_list(self):
-        date = datetime.date(2017, 10, 10)
+        date = time.CivilTime(2017, 10, 10)
         close_prices = [
-            _make_close_price(200.0, time.FromDate(d))
+            _make_close_price(200.0, time.FromCivil(d))
             for d in trading_days.get_last_n(date, 20)
         ]
 
@@ -51,9 +49,9 @@ class EmaCalculationTest(absltest.TestCase):
             57.23, 57.17, 57.96, 58.95, 59.23, 59.41, 59.82, 60.08, 59.62, 59.85,
         ]  # yapf: disable
 
-        date = datetime.date(2019, 12, 31)
+        date = time.CivilTime(2019, 12, 31)
         close_prices = [
-            _make_close_price(value, time.FromDate(d))
+            _make_close_price(value, time.FromCivil(d))
             for value, d in zip(price_data, trading_days.get_last_n(date, 20))
         ]
 
@@ -71,7 +69,7 @@ class EmaCalculationTest(absltest.TestCase):
                 }""")
 
     def test_ema20_recursive_calculation(self):
-        date = time.FromDate(datetime.date(2020, 1, 1))
+        date = time.FromCivil(time.CivilTime(2020, 1, 1))
         close_now = _make_close_price(60.84, date)
 
         ema_last = DataEntry(
@@ -94,9 +92,9 @@ class EmaCalculationTest(absltest.TestCase):
                 }""")
 
     def test_raise_when_inputs_do_not_meet_accpeted_input_shapes(self):
-        date = datetime.date(2017, 10, 10)
+        date = time.CivilTime(2017, 10, 10)
         close_prices = [
-            _make_close_price(200.0, time.FromDate(d))
+            _make_close_price(200.0, time.FromCivil(d))
             for d in trading_days.get_last_n(date, 19)
         ]
 

--- a/xlab/data/pipeline/produce_calc_fn_test.py
+++ b/xlab/data/pipeline/produce_calc_fn_test.py
@@ -1,4 +1,3 @@
-import datetime
 import random
 from typing import List
 
@@ -40,8 +39,8 @@ def get_close_prices_for_ema20(t: time.Time, symbol: str) -> List[DataEntry]:
     ]  # yapf: disable
 
     close_prices = [
-        _make_close_price(symbol, value, time.FromDate(d)) for value, d in zip(
-            price_data, trading_days.get_last_n(time.ToDate(t), 20))
+        _make_close_price(symbol, value, time.FromCivil(d)) for value, d in zip(
+            price_data, trading_days.get_last_n(time.ToCivil(t), 20))
     ]
     random.shuffle(close_prices)
     return close_prices
@@ -98,7 +97,7 @@ class ProduceCalcFnTest(absltest.TestCase):
             assert_that(out, equal_to([]))
 
     def test_produce_initial_calc_fn(self):
-        t = time.FromDate(datetime.date(2019, 12, 31))
+        t = time.FromCivil(time.CivilTime(2019, 12, 31))
         inputs = get_close_prices_for_ema20(t, 'TEST')
         with TestPipeline() as p:
             out = (p \
@@ -108,7 +107,7 @@ class ProduceCalcFnTest(absltest.TestCase):
             assert_that(out, equal_to([expected_ema20d_test()]))
 
     def test_produce_initial_calc_fn_ignores_irrelevant_data(self):
-        t = time.FromDate(datetime.date(2019, 12, 31))
+        t = time.FromCivil(time.CivilTime(2019, 12, 31))
         inputs = get_close_prices_for_ema20(t, 'TEST')
         inputs.append(_make_close_price('X', 123.45, t))
         with TestPipeline() as p:
@@ -119,7 +118,7 @@ class ProduceCalcFnTest(absltest.TestCase):
             assert_that(out, equal_to([expected_ema20d_test()]))
 
     def test_produce_initial_calc_fn_not_enough_data(self):
-        t = time.FromDate(datetime.date(2019, 12, 31))
+        t = time.FromCivil(time.CivilTime(2019, 12, 31))
         inputs = get_close_prices_for_ema20(t, 'TEST')[:19]
         with TestPipeline() as p:
             out = (p \
@@ -129,7 +128,7 @@ class ProduceCalcFnTest(absltest.TestCase):
             assert_that(out, equal_to([]))
 
     def test_produce_initial_calc_fn_multiple_symbols(self):
-        t = time.FromDate(datetime.date(2019, 12, 31))
+        t = time.FromCivil(time.CivilTime(2019, 12, 31))
         inputs = [
             *get_close_prices_for_ema20(t, 'TEST'),
             *get_close_prices_for_ema20(t, 'IBM')
@@ -155,7 +154,7 @@ class ProduceCalcFnTest(absltest.TestCase):
                 ]))
 
     def test_produce_recursive_calc_fn(self):
-        t = time.FromDate(datetime.date(2019, 12, 31))
+        t = time.FromCivil(time.CivilTime(2019, 12, 31))
         inputs = get_recursive_inputs_for_ema20(t, 'TEST')
         with TestPipeline() as p:
             out = (p \
@@ -165,7 +164,7 @@ class ProduceCalcFnTest(absltest.TestCase):
             assert_that(out, equal_to([expected_recursive_ema20d_test()]))
 
     def test_produce_recursive_calc_fn_with_swapped_inputs(self):
-        t = time.FromDate(datetime.date(2019, 12, 31))
+        t = time.FromCivil(time.CivilTime(2019, 12, 31))
         inputs = reversed(get_recursive_inputs_for_ema20(t, 'TEST'))
         with TestPipeline() as p:
             out = (p \
@@ -175,7 +174,7 @@ class ProduceCalcFnTest(absltest.TestCase):
             assert_that(out, equal_to([expected_recursive_ema20d_test()]))
 
     def test_produce_recursive_calc_fn_with_extra_data(self):
-        t = time.FromDate(datetime.date(2019, 12, 31))
+        t = time.FromCivil(time.CivilTime(2019, 12, 31))
         inputs = [
             *get_recursive_inputs_for_ema20(t, 'TEST'),
             *get_close_prices_for_ema20(t, 'IBM')

--- a/xlab/trading/dates/BUILD
+++ b/xlab/trading/dates/BUILD
@@ -9,6 +9,7 @@ py_library(
     data = ["data/us_trading_days.txt"],
     srcs_version = "PY3",
     deps = [
+        "//xlab/base:time",
         "@rules_python//python/runfiles",
     ],
 )

--- a/xlab/trading/dates/trading_days.py
+++ b/xlab/trading/dates/trading_days.py
@@ -1,10 +1,11 @@
 import abc
 import bisect
-import datetime
 import functools
 from typing import List, Optional, Tuple
 
 from rules_python.python.runfiles import runfiles
+
+from xlab.base import time
 
 
 class TradingDayFinderInterface(abc.ABC):
@@ -15,33 +16,33 @@ class TradingDayFinderInterface(abc.ABC):
     """
 
     @abc.abstractmethod
-    def is_trading_day(self, date: datetime.date) -> bool:
+    def is_trading_day(self, date: time.CivilTime) -> bool:
         pass
 
     @abc.abstractmethod
     def get_last_n(self,
-                   date: datetime.date,
+                   date: time.CivilTime,
                    n: int,
-                   include_input_date: bool = True) -> List[datetime.date]:
+                   include_input_date: bool = True) -> List[time.CivilTime]:
         pass
 
     @abc.abstractmethod
     def get_next_n(self,
-                   date: datetime.date,
+                   date: time.CivilTime,
                    n: int,
-                   include_input_date: bool = False) -> List[datetime.date]:
+                   include_input_date: bool = False) -> List[time.CivilTime]:
         pass
 
 
 class TradingDayFinder(TradingDayFinderInterface):
 
-    def __init__(self, trading_days: List[datetime.date]):
+    def __init__(self, trading_days: List[time.CivilTime]):
         self._trading_days = trading_days
 
-    def range(self) -> Tuple[datetime.date, datetime.date]:
+    def range(self) -> Tuple[time.CivilTime, time.CivilTime]:
         return (self._trading_days[0], self._trading_days[-1])
 
-    def is_trading_day(self, date: datetime.date) -> bool:
+    def is_trading_day(self, date: time.CivilTime) -> bool:
         start, end = self.range()
         if date < start or date > end:
             raise ValueError(
@@ -55,9 +56,9 @@ class TradingDayFinder(TradingDayFinderInterface):
             return False
 
     def get_last_n(self,
-                   date: datetime.date,
+                   date: time.CivilTime,
                    n: int,
-                   include_input_date: bool = True) -> List[datetime.date]:
+                   include_input_date: bool = True) -> List[time.CivilTime]:
         if (n <= 0):
             raise ValueError('n must be greater than zero')
         i = self._index(date)
@@ -65,40 +66,37 @@ class TradingDayFinder(TradingDayFinderInterface):
         return self._trading_days[max(0, i - n):i]
 
     def get_next_n(self,
-                   date: datetime.date,
+                   date: time.CivilTime,
                    n: int,
-                   include_input_date: bool = False) -> List[datetime.date]:
+                   include_input_date: bool = False) -> List[time.CivilTime]:
         if (n <= 0):
             raise ValueError('n must be greater than zero')
         i = self._index(date)
         i += not include_input_date and self._trading_days[i] == date
         return self._trading_days[i:min(i + n, len(self._trading_days))]
 
-    def _index(self, date: datetime.date) -> Optional[int]:
+    def _index(self, date: time.CivilTime) -> Optional[int]:
         return bisect.bisect_left(self._trading_days, date)
 
 
 @functools.lru_cache()
 def get_trading_day_finder():
     with open("xlab/trading/dates/data/us_trading_days.txt", "r") as f:
-        dates = [
-            datetime.date.fromisoformat(line.rstrip())
-            for line in f.readlines()
-        ]
+        dates = [time.ParseCivilTime(line.rstrip()) for line in f.readlines()]
         return TradingDayFinder(dates)
 
 
-def is_trading_day(date: datetime.date) -> bool:
+def is_trading_day(date: time.CivilTime) -> bool:
     return get_trading_day_finder().is_trading_day(date)
 
 
-def get_last_n(date: datetime.date,
+def get_last_n(date: time.CivilTime,
                n: int,
-               include_input_date: bool = True) -> List[datetime.date]:
+               include_input_date: bool = True) -> List[time.CivilTime]:
     return get_trading_day_finder().get_last_n(date, n, include_input_date)
 
 
-def get_next_n(date: datetime.date,
+def get_next_n(date: time.CivilTime,
                n: int,
-               include_input_date: bool = False) -> List[datetime.date]:
+               include_input_date: bool = False) -> List[time.CivilTime]:
     return get_trading_day_finder().get_next_n(date, n, include_input_date)

--- a/xlab/trading/dates/trading_days_test.py
+++ b/xlab/trading/dates/trading_days_test.py
@@ -1,7 +1,6 @@
-import datetime
-
 from absl.testing import absltest
 
+from xlab.base import time
 from xlab.trading.dates import trading_days
 
 
@@ -9,62 +8,62 @@ class TradingDayFinderTest(absltest.TestCase):
 
     def test_is_trading_day(self):
         finder = trading_days.get_trading_day_finder()
-        self.assertFalse(finder.is_trading_day(datetime.date(2017, 1, 2)))
-        self.assertTrue(finder.is_trading_day(datetime.date(2017, 1, 3)))
-        self.assertTrue(finder.is_trading_day(datetime.date(2018, 7, 3)))
-        self.assertFalse(finder.is_trading_day(datetime.date(2018, 7, 4)))
-        self.assertTrue(finder.is_trading_day(datetime.date(2020, 5, 22)))
-        self.assertFalse(finder.is_trading_day(datetime.date(2020, 5, 25)))
+        self.assertFalse(finder.is_trading_day(time.CivilTime(2017, 1, 2)))
+        self.assertTrue(finder.is_trading_day(time.CivilTime(2017, 1, 3)))
+        self.assertTrue(finder.is_trading_day(time.CivilTime(2018, 7, 3)))
+        self.assertFalse(finder.is_trading_day(time.CivilTime(2018, 7, 4)))
+        self.assertTrue(finder.is_trading_day(time.CivilTime(2020, 5, 22)))
+        self.assertFalse(finder.is_trading_day(time.CivilTime(2020, 5, 25)))
 
     def test_is_trading_day_raises_for_unknown_dates(self):
         finder = trading_days.get_trading_day_finder()
         start, end = finder.range()
         with self.assertRaisesRegex(ValueError, f'{start}, {end}'):
-            finder.is_trading_day(start - datetime.timedelta(days=1))
+            finder.is_trading_day(start.subtract(days=1))
         with self.assertRaisesRegex(ValueError, f'{start}, {end}'):
-            finder.is_trading_day(end + datetime.timedelta(days=1))
+            finder.is_trading_day(end.add(days=1))
 
     def test_get_last_n(self):
         finder = trading_days.get_trading_day_finder()
         # 2020-05-25 is not a traiding date.
         self.assertSequenceEqual(
-            finder.get_last_n(datetime.date(2020, 5, 25), 1),
-            [datetime.date(2020, 5, 22)])
+            finder.get_last_n(time.CivilTime(2020, 5, 25), 1),
+            [time.CivilTime(2020, 5, 22)])
         self.assertSequenceEqual(
-            finder.get_last_n(datetime.date(2020, 5, 22), 1),
-            [datetime.date(2020, 5, 22)])
+            finder.get_last_n(time.CivilTime(2020, 5, 22), 1),
+            [time.CivilTime(2020, 5, 22)])
         self.assertSequenceEqual(
-            finder.get_last_n(datetime.date(2020, 5, 25), 6), [
-                datetime.date(2020, 5, 15),
-                datetime.date(2020, 5, 18),
-                datetime.date(2020, 5, 19),
-                datetime.date(2020, 5, 20),
-                datetime.date(2020, 5, 21),
-                datetime.date(2020, 5, 22),
+            finder.get_last_n(time.CivilTime(2020, 5, 25), 6), [
+                time.CivilTime(2020, 5, 15),
+                time.CivilTime(2020, 5, 18),
+                time.CivilTime(2020, 5, 19),
+                time.CivilTime(2020, 5, 20),
+                time.CivilTime(2020, 5, 21),
+                time.CivilTime(2020, 5, 22),
             ])
 
     def test_get_last_n_without_input_date(self):
         finder = trading_days.get_trading_day_finder()
         self.assertSequenceEqual(
-            finder.get_last_n(datetime.date(2020, 5, 25),
+            finder.get_last_n(time.CivilTime(2020, 5, 25),
                               1,
                               include_input_date=False),
-            [datetime.date(2020, 5, 22)])
+            [time.CivilTime(2020, 5, 22)])
         self.assertSequenceEqual(
-            finder.get_last_n(datetime.date(2020, 5, 22),
+            finder.get_last_n(time.CivilTime(2020, 5, 22),
                               1,
                               include_input_date=False),
-            [datetime.date(2020, 5, 21)])
+            [time.CivilTime(2020, 5, 21)])
         self.assertSequenceEqual(
-            finder.get_last_n(datetime.date(2020, 5, 22),
+            finder.get_last_n(time.CivilTime(2020, 5, 22),
                               6,
                               include_input_date=False), [
-                                  datetime.date(2020, 5, 14),
-                                  datetime.date(2020, 5, 15),
-                                  datetime.date(2020, 5, 18),
-                                  datetime.date(2020, 5, 19),
-                                  datetime.date(2020, 5, 20),
-                                  datetime.date(2020, 5, 21),
+                                  time.CivilTime(2020, 5, 14),
+                                  time.CivilTime(2020, 5, 15),
+                                  time.CivilTime(2020, 5, 18),
+                                  time.CivilTime(2020, 5, 19),
+                                  time.CivilTime(2020, 5, 20),
+                                  time.CivilTime(2020, 5, 21),
                               ])
 
     def test_get_last_n_at_start(self):
@@ -74,9 +73,8 @@ class TradingDayFinderTest(absltest.TestCase):
         self.assertSequenceEqual(finder.get_last_n(start, 2), [start])
         self.assertSequenceEqual(finder.get_last_n(start, 20), [start])
         # The current range start is a Monday
-        self.assertSequenceEqual(
-            finder.get_last_n(start + datetime.timedelta(days=4), 5),
-            [start + datetime.timedelta(days=i) for i in range(5)])
+        self.assertSequenceEqual(finder.get_last_n(start.add(days=4), 5),
+                                 [start.add(days=i) for i in range(5)])
 
         self.assertSequenceEqual(
             finder.get_last_n(start, 1, include_input_date=False), [])
@@ -86,43 +84,43 @@ class TradingDayFinderTest(absltest.TestCase):
     def test_get_next_n(self):
         finder = trading_days.get_trading_day_finder()
         self.assertSequenceEqual(
-            finder.get_next_n(datetime.date(2020, 5, 25), 1),
-            [datetime.date(2020, 5, 26)])
+            finder.get_next_n(time.CivilTime(2020, 5, 25), 1),
+            [time.CivilTime(2020, 5, 26)])
         self.assertSequenceEqual(
-            finder.get_next_n(datetime.date(2020, 5, 26), 1),
-            [datetime.date(2020, 5, 27)])
+            finder.get_next_n(time.CivilTime(2020, 5, 26), 1),
+            [time.CivilTime(2020, 5, 27)])
         self.assertSequenceEqual(
-            finder.get_next_n(datetime.date(2020, 5, 23), 6), [
-                datetime.date(2020, 5, 26),
-                datetime.date(2020, 5, 27),
-                datetime.date(2020, 5, 28),
-                datetime.date(2020, 5, 29),
-                datetime.date(2020, 6, 1),
-                datetime.date(2020, 6, 2),
+            finder.get_next_n(time.CivilTime(2020, 5, 23), 6), [
+                time.CivilTime(2020, 5, 26),
+                time.CivilTime(2020, 5, 27),
+                time.CivilTime(2020, 5, 28),
+                time.CivilTime(2020, 5, 29),
+                time.CivilTime(2020, 6, 1),
+                time.CivilTime(2020, 6, 2),
             ])
 
     def test_get_next_n_with_input_date(self):
         finder = trading_days.get_trading_day_finder()
         self.assertSequenceEqual(
-            finder.get_next_n(datetime.date(2020, 5, 25),
+            finder.get_next_n(time.CivilTime(2020, 5, 25),
                               1,
                               include_input_date=True),
-            [datetime.date(2020, 5, 26)])
+            [time.CivilTime(2020, 5, 26)])
         self.assertSequenceEqual(
-            finder.get_next_n(datetime.date(2020, 5, 26),
+            finder.get_next_n(time.CivilTime(2020, 5, 26),
                               1,
                               include_input_date=True),
-            [datetime.date(2020, 5, 26)])
+            [time.CivilTime(2020, 5, 26)])
         self.assertSequenceEqual(
-            finder.get_next_n(datetime.date(2020, 5, 26),
+            finder.get_next_n(time.CivilTime(2020, 5, 26),
                               6,
                               include_input_date=True), [
-                                  datetime.date(2020, 5, 26),
-                                  datetime.date(2020, 5, 27),
-                                  datetime.date(2020, 5, 28),
-                                  datetime.date(2020, 5, 29),
-                                  datetime.date(2020, 6, 1),
-                                  datetime.date(2020, 6, 2),
+                                  time.CivilTime(2020, 5, 26),
+                                  time.CivilTime(2020, 5, 27),
+                                  time.CivilTime(2020, 5, 28),
+                                  time.CivilTime(2020, 5, 29),
+                                  time.CivilTime(2020, 6, 1),
+                                  time.CivilTime(2020, 6, 2),
                               ])
 
     def test_get_next_n_at_end(self):
@@ -132,8 +130,8 @@ class TradingDayFinderTest(absltest.TestCase):
         self.assertSequenceEqual(finder.get_next_n(end, 2), [])
         self.assertSequenceEqual(finder.get_next_n(end, 20), [])
         # The current range end is a Tuesday
-        self.assertSequenceEqual(
-            finder.get_next_n(end - datetime.timedelta(days=1), 1), [end])
+        self.assertSequenceEqual(finder.get_next_n(end.subtract(days=1), 1),
+                                 [end])
 
         self.assertSequenceEqual(
             finder.get_next_n(end, 1, include_input_date=True), [end])


### PR DESCRIPTION
and add helpers to work with timezone conversions.

This is based on absl::CivilTime: https://github.com/abseil/abseil-cpp/blob/master/absl/time/civil_time.h