### PR TITLE
Fix mongo time

### DIFF
--- a/xlab/base/time.py
+++ b/xlab/base/time.py
@@ -142,7 +142,9 @@ def FormatCivilTime(ct: CivilTime) -> str:
 
 
 def ParseCivilTime(isoformat: str) -> CivilTime:
-    ct = CivilTime.fromisoformat(isoformat)
+    # Right now |fromisoformat| doesn't handle Z:
+    #   https://discuss.python.org/t/parse-z-timezone-suffix-in-datetime/2220
+    ct = CivilTime.fromisoformat(isoformat.rstrip('Z'))
     return _make_datetime_with_preferred_dst(ct, UTC).naive()
 
 

--- a/xlab/data/converters/mongo.py
+++ b/xlab/data/converters/mongo.py
@@ -2,18 +2,25 @@ from typing import Any, Dict
 
 from google.protobuf import json_format
 
+from xlab.base import time
 from xlab.data.proto import data_entry_pb2
 
 DataEntry = data_entry_pb2.DataEntry
 
 
 def to_mongo_doc(data_entry: DataEntry) -> Dict[Any, Any]:
-    return json_format.MessageToDict(data_entry, use_integers_for_enums=True)
+    bson = json_format.MessageToDict(data_entry, use_integers_for_enums=True)
+    # Store the timestamp as mongo Date by passing a Datetime object.
+    bson['timestamp'] = time.ParseCivilTime(bson['timestamp'])
+    return bson
 
 
-def from_mongo_doc(document: Dict[Any, Any]) -> DataEntry:
+def from_mongo_doc(bson: Dict[Any, Any]) -> DataEntry:
+    # NOTE: |isoformat| is used here, as the timestamp from mongo will be the
+    # built-in datetime class. Also add the 'Z' which is expected by ParseDict
+    # and is consistent withMessageToDict.
+    bson['timestamp'] = bson['timestamp'].isoformat() + 'Z'
+
     # ParseDict takes a message type and also return it as results
     # ignore_unknown_fields is used to ignore mongo's _id field.
-    return json_format.ParseDict(document,
-                                 DataEntry(),
-                                 ignore_unknown_fields=True)
+    return json_format.ParseDict(bson, DataEntry(), ignore_unknown_fields=True)

--- a/xlab/data/pipeline/BUILD
+++ b/xlab/data/pipeline/BUILD
@@ -9,6 +9,7 @@ py_library(
     srcs_version = "PY3",
     deps = [
         "//xlab/data/converters:mongo",
+        "//xlab/data/store/mongo:constants",
         requirement("apache-beam"),
     ],
 )
@@ -41,7 +42,9 @@ py_binary(
         ":mongo_util",
         ":produce_calc_fn",
         "//xlab/base:time",
+        "//xlab/data/calc:registry",
         "//xlab/data/proto:data_type_py_pb2",
+        "//xlab/net/proto:time_util",
         "//xlab/trading/dates:trading_days",
         requirement("absl-py"),
         requirement("apache-beam"),

--- a/xlab/data/pipeline/mongo_util.py
+++ b/xlab/data/pipeline/mongo_util.py
@@ -7,15 +7,16 @@ from apache_beam.transforms import ptransform
 from apache_beam.io import mongodbio
 
 from xlab.data.converters import mongo as mongo_converter
+from xlab.data.store.mongo import constants
 
 asdict = dataclasses.asdict
 
 
 @dataclasses.dataclass(frozen=True)
 class MongoOptionBase:
-    uri: str = 'mongodb://localhost:27017'
-    db: str = 'xlab'
-    coll: str = 'data_entries'
+    uri: str
+    db: str
+    coll: str
     extra_client_params: Optional[Dict] = None
 
 
@@ -34,9 +35,22 @@ class MongoWriteOption(MongoOptionBase):
     batch_size: int = 100
 
 
+def default_read_option(filter=None, projection=None) -> MongoReadOption:
+    return MongoReadOption(uri=constants.MONGO_LOCAL_URI,
+                           db=constants.XLAB_DB,
+                           coll=constants.DATA_ENTRY_COL,
+                           filter=filter,
+                           projection=projection)
+
+
+def default_write_option() -> MongoReadOption:
+    return MongoWriteOption(uri=constants.MONGO_LOCAL_URI,
+                            db=constants.XLAB_DB,
+                            coll=constants.DATA_ENTRY_COL)
+
+
 @ptransform.ptransform_fn
 def ReadDataFromMongoDB(pbegin: beam.pvalue.PBegin, option: MongoReadOption):
-    print(option)
     return (pbegin \
         | 'ReadFromMongoDB' >> mongodbio.ReadFromMongoDB(**asdict(option))
         | 'ToDataEntry' >> beam.Map(mongo_converter.from_mongo_doc))

--- a/xlab/data/pipeline/produce_calc_fn.py
+++ b/xlab/data/pipeline/produce_calc_fn.py
@@ -29,7 +29,7 @@ def produce_source_calc_fn(inputs: PCollection, calc_type: DataType.Enum,
                            t: time.Time) -> PCollection:
     calc_producer = calc_registry.get_calc_producer(calc_type)
     inputs_shape = calc_producer.source_inputs_shape(t)
-    return _produce_calc_fn(inputs, calc_producer, inputs_shape)
+    return inputs | produce_calc_fn(calc_producer, inputs_shape)
 
 
 @ptransform.ptransform_fn
@@ -37,12 +37,12 @@ def produce_recursive_calc_fn(inputs: PCollection, calc_type: DataType.Enum,
                               t: time.Time) -> PCollection:
     calc_producer = calc_registry.get_calc_producer(calc_type)
     inputs_shape = calc_producer.recursive_inputs_shape(t)
-    return _produce_calc_fn(inputs, calc_producer, inputs_shape)
+    return inputs | produce_calc_fn(calc_producer, inputs_shape)
 
 
-# Note this convenience function is not decorated with @ptransform_fn.
-def _produce_calc_fn(inputs: PCollection, calc_producer: calc.CalcProducer,
-                     inputs_shape: calc.CalcInputs) -> PCollection:
+@ptransform.ptransform_fn
+def produce_calc_fn(inputs: PCollection, calc_producer: calc.CalcProducer,
+                    inputs_shape: calc.CalcInputs) -> PCollection:
     return (inputs \
         | 'FilterByInputsShape' >> beam.Filter(filter_by_input_shapes,
                                                inputs_shape) \

--- a/xlab/data/store/impl_test_factory.py
+++ b/xlab/data/store/impl_test_factory.py
@@ -24,7 +24,7 @@ def get_data_entry_one():
         data_type: CLOSE_PRICE
         value: 290.87
         timestamp {
-        seconds: 1234567
+            seconds: 1234567
         }""", data_entry_pb2.DataEntry)
 
 
@@ -36,7 +36,7 @@ def get_data_entry_two():
         data_type: CLOSE_PRICE
         value: 300.01
         timestamp {
-        seconds: 567890
+            seconds: 567890
         }""", data_entry_pb2.DataEntry)
 
 
@@ -48,7 +48,7 @@ def get_data_entry_three():
         data_type: CLOSE_PRICE
         value: 115.32
         timestamp {
-        seconds: 1234567
+            seconds: 1234567
         }
         """, data_entry_pb2.DataEntry)
 

--- a/xlab/data/store/mongo/BUILD
+++ b/xlab/data/store/mongo/BUILD
@@ -4,10 +4,17 @@ load("@py_deps//:requirements.bzl", "requirement")
 package(default_visibility = ["//xlab:internal"])
 
 py_library(
+    name = "constants",
+    srcs = ["constants.py"],
+    srcs_version = "PY3",
+)
+
+py_library(
     name = "db_client",
     srcs = ["db_client.py"],
     srcs_version = "PY3",
     deps = [
+        ":constants",
         requirement("pymongo"),
     ],
 )
@@ -26,12 +33,13 @@ py_library(
     srcs = ["store.py"],
     srcs_version = "PY3",
     deps = [
+        ":constants",
         ":db_client",
+        "//xlab/base:time",
         "//xlab/data/converters:mongo",
         "//xlab/data/proto:data_entry_py_pb2",
         "//xlab/data/store",
         "//xlab/data/store:key",
-        "//xlab/net/proto:time_util",
         "//xlab/util/status:errors",
         requirement("pymongo"),
         requirement("protobuf"),

--- a/xlab/data/store/mongo/constants.py
+++ b/xlab/data/store/mongo/constants.py
@@ -1,0 +1,5 @@
+LOCAL_HOST = 'localhost'
+MONGO_DEFAULT_PORT = 27017
+MONGO_LOCAL_URI = f'mongodb://{LOCAL_HOST}:{MONGO_DEFAULT_PORT}'
+XLAB_DB = 'xlab'
+DATA_ENTRY_COL = 'data_entries'

--- a/xlab/data/store/mongo/db_client.py
+++ b/xlab/data/store/mongo/db_client.py
@@ -1,9 +1,8 @@
 import pymongo
 
-_LOCAL_HOST = 'localhost'
-_DEFAULT_PORT = 27017
+from xlab.data.store.mongo import constants
 
 
-def connect(host: str = _LOCAL_HOST,
-            port: int = _DEFAULT_PORT) -> pymongo.MongoClient:
+def connect(host: str = constants.LOCAL_HOST,
+            port: int = constants.MONGO_DEFAULT_PORT) -> pymongo.MongoClient:
     return pymongo.MongoClient(host, port)

--- a/xlab/data/store/mongo/store.py
+++ b/xlab/data/store/mongo/store.py
@@ -2,14 +2,14 @@ from typing import Callable, Dict, List, Tuple
 
 from google.protobuf import timestamp_pb2
 import pymongo
-from pymongo import client_session
 
+from xlab.base import time
 from xlab.data import store
 from xlab.data.converters import mongo as mongo_converter
 from xlab.data.proto import data_entry_pb2
 from xlab.data.store import key
+from xlab.data.store.mongo import constants
 from xlab.data.store.mongo import db_client
-from xlab.net.proto import time_util
 from xlab.util.status import errors
 
 DataEntry = data_entry_pb2.DataEntry
@@ -17,13 +17,10 @@ DataEntry = data_entry_pb2.DataEntry
 
 class MongoDataStore(store.DataStore):
 
-    _DATABASE = 'xlab'
-    _DATA_ENTRY_COLLECTION = 'data_entries'
-
     def __init__(self, client: pymongo.MongoClient = db_client.connect()):
         self._client = client
-        self._db = self._client[self._DATABASE]
-        self._coll = self._db[self._DATA_ENTRY_COLLECTION]
+        self._db = self._client[constants.XLAB_DB]
+        self._coll = self._db[constants.DATA_ENTRY_COL]
 
     def add(self, data_entry: DataEntry):
         # TODO: causal_consistency should be supported with |start_session|;
@@ -70,6 +67,5 @@ class MongoDataStore(store.DataStore):
         if lookup_key.data_type:
             res['dataType'] = lookup_key.data_type
         if lookup_key.timestamp:
-            res['timestamp'] = time_util.from_time(
-                lookup_key.timestamp).ToJsonString()
+            res['timestamp'] = time.ToCivil(lookup_key.timestamp)
         return res

--- a/xlab/net/proto/time_util.py
+++ b/xlab/net/proto/time_util.py
@@ -10,3 +10,11 @@ def from_time(t: time.Time) -> timestamp_pb2.Timestamp:
     pb = timestamp_pb2.Timestamp()
     pb.FromNanoseconds(time.ToUnixNanos(t))
     return pb
+
+
+def to_civl(pb: timestamp_pb2.Timestamp) -> time.CivilTime:
+    return time.ToCivil(to_time(pb))
+
+
+def from_civil(ct: time.CivilTime) -> timestamp_pb2.Timestamp:
+    return from_time(time.FromCivil(ct))


### PR DESCRIPTION
Fix the issue that mongo timestamp was a string...instead of a datetime object, and allow filtering mongodbio collection using the date range in the
calculation producing beam program.