### PR TITLE
Bump Rust Protobuf package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,8 @@ commands:
             export PATH="${HOME}/.cargo/bin:${PATH}"
             rustc -V
 
-            cargo install cargo-raze
+            # https://github.com/google/cargo-raze/issues/179
+            cargo install cargo-raze --version=0.3.3
             make raze
 
   # Initializes the CI environment by setting up common environment variables.
@@ -107,11 +108,13 @@ jobs:
       - install_python
       - install_rust
       - init_environment
-      - run: |
-          # Virtual env can only take effect if activated here.
-          source .venv/bin/activate
-          bazel build xlab/...
-          bazel test xlab/...
+      - run:
+          name: Build and test
+          command: |
+            # Virtual env can only take effect if activated here.
+            source .venv/bin/activate
+            bazel build xlab/...
+            bazel test xlab/...
 
       - run:
           name: Copy out bazel test results

--- a/third_party/cargo/Cargo.toml
+++ b/third_party/cargo/Cargo.toml
@@ -8,20 +8,20 @@ path = "fake_lib.rs"
 
 [dependencies]
 approx = "=0.3.2"
-protobuf =  { version = "=1.6.0", features = ["with-bytes"] }
+protobuf =  { version = "=2.0.0", features = ["with-bytes"] }
 
 [raze]
 genmode = "Remote"
 workspace_path = "//third_party/cargo"
 output_buildfile_suffix = "BUILD"
 
-[raze.crates.protobuf.'1.6.0']
+[raze.crates.protobuf.'2.0.0']
 gen_buildrs = true
 buildrs_additional_environment_variables = [
     "RUSTC=$$PWD/$(location @xlab//xlab/third_party/cargo:rustc)",
-    "CARGO_PKG_VERSION=1.6.0",
+    "CARGO_PKG_VERSION=2.0.0",
 ]
 
-[raze.crates.protobuf-codegen.'1.6.0']
+[raze.crates.protobuf-codegen.'2.0.0']
 gen_buildrs = true
 extra_aliased_targets = ["cargo_bin_protoc_gen_rust"]

--- a/third_party/cargo/Cargo.toml
+++ b/third_party/cargo/Cargo.toml
@@ -8,20 +8,21 @@ path = "fake_lib.rs"
 
 [dependencies]
 approx = "=0.3.2"
-protobuf =  { version = "=2.0.0", features = ["with-bytes"] }
+protobuf =  { version = "=2.15.1", features = ["with-bytes"] }
+protobuf-codegen = "=2.15.1"
 
 [raze]
 genmode = "Remote"
 workspace_path = "//third_party/cargo"
 output_buildfile_suffix = "BUILD"
 
-[raze.crates.protobuf.'2.0.0']
+[raze.crates.protobuf.'2.15.1']
 gen_buildrs = true
 buildrs_additional_environment_variables = [
-    "RUSTC=$$PWD/$(location @xlab//xlab/third_party/cargo:rustc)",
-    "CARGO_PKG_VERSION=2.0.0",
+    "RUSTC=$$PWD/$(location @xlab//third_party/cargo:rustc)",
+    "CARGO_PKG_VERSION=2.15.1",
 ]
 
-[raze.crates.protobuf-codegen.'2.0.0']
+[raze.crates.protobuf-codegen.'2.15.1']
 gen_buildrs = true
 extra_aliased_targets = ["cargo_bin_protoc_gen_rust"]


### PR DESCRIPTION
This change (and maybe the previous as well) do no work with cargo-raze > 0.3.3. See google/cargo-raze#179